### PR TITLE
Update ps3joy/package.xml URLs with github user ros to ros-drivers

### DIFF
--- a/ps3joy/package.xml
+++ b/ps3joy/package.xml
@@ -19,8 +19,8 @@
   <author>Melonee Wise</author>
 
   <url type="website">http://www.ros.org/wiki/ps3joy</url>
-  <url type="development">https://github.com/ros/joystick_drivers</url>
-  <url type="bugtracker">https://github.com/ros/joystick_drivers/issues</url>
+  <url type="development">https://github.com/ros-drivers/joystick_drivers</url>
+  <url type="bugtracker">https://github.com/ros-drivers/joystick_drivers/issues</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   


### PR DESCRIPTION
That one seems to have been overlooked.
