### PR TITLE
Only install joy_node when it actually gets built.

### DIFF
--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -16,17 +16,14 @@ if(HAVE_LINUX_JOYSTICK_H)
   include_directories(msg/cpp ${catkin_INCLUDE_DIRS})
   add_executable(joy_node src/joy_node.cpp)
   target_link_libraries(joy_node ${catkin_LIBRARIES})
+
+  install(TARGETS joy_node
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 else(HAVE_LINUX_JOYSTICK_H)
   message("Warning: no <linux/joystick.h>; won't build joy node")
 endif(HAVE_LINUX_JOYSTICK_H)
 
 #catkin_add_nosetests(test/test_joy_msg_migration.py)
-
-# Install targets
-install(TARGETS joy_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY migration_rules
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
This fixes an install issue on OS X and other non-Linux systems.

Apologies for the commit earlier— I made the fix in the Github webUI and forgot I had write access to the repo.
