### PR TITLE
Remove stray architechture_independent flags

### DIFF
--- a/joy/package.xml
+++ b/joy/package.xml
@@ -37,6 +37,5 @@
 
   <export>
     <rosbag migration_rule_file="migration_rules/Joy.bmr"/>
-    <architecture_independent/>
   </export>
 </package>

--- a/ps3joy/package.xml
+++ b/ps3joy/package.xml
@@ -41,8 +41,4 @@
   <run_depend>joystick</run_depend>
   <run_depend>bluez</run_depend>
   <run_depend>python-bluez</run_depend>
-
-  <export>
-    <architecture_independent/>
-  </export>
 </package>

--- a/spacenav_node/package.xml
+++ b/spacenav_node/package.xml
@@ -28,8 +28,4 @@
   <run_depend>libspnav-dev</run_depend> 
   <run_depend>libx11-dev</run_depend> 
   <run_depend>spacenavd</run_depend> 
-
-  <export>
-    <architecture_independent/>
-  </export>
 </package>


### PR DESCRIPTION
This flag should be used for packages which do not contain architecture-specific files. Compiled binaries are such a file, and these packages contain them.

Please backport this patch to `groovy-devel` as well, and a release bump would be appreciated.

Thanks!

See:
- http://www.ros.org/reps/rep-0127.html#architecture-independent
- https://github.com/ros-infrastructure/bloom/pull/270
