### PR TITLE
C++ Implementation of Wiimote Controller Node

### DIFF
--- a/wiimote/CMakeLists.txt
+++ b/wiimote/CMakeLists.txt
@@ -2,10 +2,22 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(wiimote)
 
+# Save the command line compile commands in the build output
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+# View the makefile commands during build
+#set(CMAKE_VERBOSE_MAKEFILE on)
+
+# Set compile flags
+set(CMAKE_CXX_FLAGS "-fPIE -fPIC -std=c++11 -O2 -D_FORTIFY_SOURCE=2 -fstack-protector -Wformat -Wformat-security -Wall ${CMAKE_CXX_FLAGS}")
+# Flags executables
+set(CMAKE_EXE_LINKER_FLAGS "-pie -z noexecstack -z relro -z now")
+# Flags shared libraries
+set(CMAKE_SHARED_LINKER_FLAGS "-z noexecstack -z relro -z now ${CMAKE_SHARED_LINKER_FLAGS}")
+
 # Load catkin and all dependencies required for this package
-set(CATKIN_DEPS geometry_msgs sensor_msgs std_msgs std_srvs rospy roslib genmsg)
+set(CATKIN_DEPS geometry_msgs sensor_msgs std_msgs std_srvs rospy roscpp roslib genmsg)
 set(ROSDEP_DEPS python-numpy python-cwiid)
-find_package(catkin REQUIRED ${CATKIN_DEPS})
+find_package(catkin REQUIRED ${CATKIN_DEPS} roslint)
 
 catkin_python_setup()
 
@@ -19,10 +31,50 @@ add_message_files(
 
 generate_messages(DEPENDENCIES geometry_msgs std_msgs sensor_msgs)
 
-# define the package
-catkin_package(DEPENDS ${CATKIN_DEPS})
+# ROS Lint the code
+roslint_cpp()
+#roslint_python()  # TODO(jbohren): ROS Lint the Python code
+roslint_add_test()
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  INCLUDE_DIRS include
+  DEPENDS ${CATKIN_DEPS}
+  bluetooth cwiid
+)
+
+## Specify additional locations of header files
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## C++ Wiimote Node: Declare cpp executables
+add_executable(wiimote_node src/wiimote_controller.cpp src/stat_vector_3d.cpp)
+target_link_libraries(wiimote_node ${catkin_LIBRARIES} bluetooth cwiid)
+add_dependencies(wiimote_node wiimote_generate_messages_cpp)
+## End of C++ Wiimote Node
+
+# Install launch files
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)
 
 # Install targets
 install(PROGRAMS nodes/feedbackTester.py  nodes/wiimote_node.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
+## Mark executables and/or libraries for installation
+install(TARGETS wiimote_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/wiimote/README.md
+++ b/wiimote/README.md
@@ -1,0 +1,29 @@
+# Wiimote Nodes
+
+See http://wiki.ros.org/wiimote for details.
+
+## wiimote_node.py
+
+Original Python version of the wiimote node.
+
+## wiimote_node
+
+The C++ implementation was designed with focus on reduced resource consumption.
+
+### Differences from Python Implementation
+* Both "/wiimote/nunchuk" and "/wiimote/classic" topics are only published
+if the Nunchuk or Classic Controller are connected to the wiimote respectively.
+* Wiimote data is only polled from the controller if the data is required
+to publish for a topic which has at least one subscriber.
+* During Calibration the joysticks (Nunchuk & Classic Controller) are polled
+to find the current position which is assumed to be the center. Not all joysticks
+rest at the theoretical center position.
+* Joysticks (Nunchuk & Classic Controller) minimum and maximum values start at
+80% of the theoretical minimum/maximum values and are dynamically updated as
+the joystick is used. The full range of values may not be reached on all joysticks
+due to physical limitations. Without this adjust, the full range from -1.0 to 1.0
+would not be reached on many joysticks.
+* Joysticks (Nunchuk & Classic Controller) center deadzone is scaled based on
+the granularity of the joystick; python code assumed the same for all.
+* Connecting an accessory (Nunchuk, Classic Controller, or MotionPlus) will
+automatically start a new calibration sequence.

--- a/wiimote/include/wiimote/stat_vector_3d.h
+++ b/wiimote/include/wiimote/stat_vector_3d.h
@@ -1,0 +1,63 @@
+/*
+ * Three dimensional statistic vector for use with the
+ * for ROS Node which interfaces with a wiimote control unit.
+ * Copyright (c) 2016, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+/*
+ * Initial C++ implementation by
+ *   Mark Horn <mark.d.horn@intel.com>
+ *
+ * Revisions:
+ *
+ */
+
+#pragma once
+#ifndef WIIMOTE_STAT_VECTOR_3D_H
+#define WIIMOTE_STAT_VECTOR_3D_H
+
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include <math.h>
+
+// The vector of 3 values collected to generate:
+// mean, standard deviation, and variance.
+
+typedef std::vector<double> TVectorDouble;
+
+class StatVector3d
+{
+public:
+  StatVector3d();
+  StatVector3d(int x, int y, int z);
+
+  void clear();
+
+  int size();
+  void addData(int x, int y, int z);
+
+  TVectorDouble getMeanRaw();
+  TVectorDouble getMeanScaled(double scale);
+  TVectorDouble getVarianceRaw();
+  TVectorDouble getVarianceScaled(double scale);
+  TVectorDouble getStandardDeviationRaw();
+  TVectorDouble getStandardDeviationScaled(double scale);
+
+private:
+  int count_;
+  std::vector<int> x_;
+  std::vector<int> y_;
+  std::vector<int> z_;
+};
+
+#endif  // WIIMOTE_STAT_VECTOR_3D_H

--- a/wiimote/include/wiimote/wiimote_controller.h
+++ b/wiimote/include/wiimote/wiimote_controller.h
@@ -1,0 +1,231 @@
+/*
+ * ROS Node for interfacing with a wiimote control unit.
+ * Copyright (c) 2016, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+/*
+ * This code is based on the original Python implementation
+ * created by Andreas Paepcke and Melonee Wise
+ *  Andreas Paepcke <paepcke@anw.willowgarage.com>
+ * with contributions by
+ *  David Lu <davidlu@wustl.edu>
+ *  Miguel Angel Julian Aguilar <miguel.angel@thecorpora.com>
+ * See https://github.com/ros-drivers/joystick_drivers/tree/indigo-devel/wiimote
+ * for details and history.
+ *
+ * This C++ implementation used the functionality of the existing
+ * Python code as the feature requirements.
+ */
+
+/*
+ * Initial C++ implementation by
+ *   Mark Horn <mark.d.horn@intel.com>
+ *
+ * Revisions:
+ *
+ */
+
+#pragma once
+#ifndef WIIMOTE_WIIMOTE_CONTROLLER_H
+#define WIIMOTE_WIIMOTE_CONTROLLER_H
+
+#include "ros/ros.h"
+#include "sensor_msgs/JoyFeedbackArray.h"
+#include "std_srvs/Empty.h"
+#include "sensor_msgs/Imu.h"
+
+#include "wiimote/stat_vector_3d.h"
+
+// We need to link against these
+#include <bluetooth/bluetooth.h>  // libbluetooth.so
+namespace wiimote_c
+{
+#include <cwiid.h>  // libcwiid.so
+}
+
+#define zeroedByCal(raw, zero, one) \
+  (((raw - zero) * 1.0) / ((one - zero) * 1.0))
+
+class WiimoteNode
+{
+public:
+  WiimoteNode();
+  ~WiimoteNode();
+  char *getBluetoothAddr();
+  void setBluetoothAddr(const char *bt_str);
+  bool pairWiimote(int flags, int timeout);
+  int unpairWiimote();
+
+  void publish();
+
+  void setLedState(uint8_t led_state);
+  void setRumbleState(uint8_t rumble);
+
+private:
+  void setReportMode(uint8_t rpt_mode);
+  void checkFactoryCalibrationData();
+  void resetMotionPlusState();
+  void resetNunchukState();
+  void resetClassicState();
+
+  ros::NodeHandle nh_;
+
+  static wiimote_c::cwiid_err_t cwiidErrorCallback;
+
+/**
+  Node [/wiimote_controller]
+  Publications:
+   * /joy [sensor_msgs/Joy]
+   * /wiimote/state [wiimote/State]
+   * /wiimote/nunchuk [sensor_msgs/Joy]
+   * /wiimote/classic [sensor_msgs/Joy]
+   * /imu/is_calibrated [std_msgs/Bool]
+   * /imu/data [sensor_msgs/Imu]
+
+  Subscriptions:
+   * /joy/set_feedback [sensor_msgs/JoyFeedbackArray]
+
+  Services:
+   * /imu/calibrate
+**/
+  void joySetFeedbackCallback(const sensor_msgs::JoyFeedbackArray::ConstPtr& feedback);
+  bool serviceImuCalibrateCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&);
+
+  bool isCollectingWiimote();
+  bool isCollectingNunchuk();
+  bool isCollectingClassic();
+  bool isCollectingMotionplus();
+
+  bool isPresentNunchuk();
+  bool isPresentClassic();
+  bool isPresentMotionplus();
+
+  bool calibrateJoystick(uint8_t stick[2], uint8_t (&center)[2], const char *name);
+  void updateJoystickMinMax(uint8_t stick[2], uint8_t (&stick_min)[2],
+      uint8_t (&stick_max)[2], const char *name);
+  void calculateJoystickAxisXY(uint8_t stick_current[2], uint8_t stick_min[2],
+      uint8_t stick_max[2], uint8_t stick_center[2], double (&stick)[2]);
+
+  void publishJoy();
+  void publishImuData();
+  void publishWiimoteState();
+  bool publishWiimoteNunchukCommon();
+  void publishWiimoteNunchuk();
+  void publishWiimoteClassic();
+
+  bool getStateSample();
+
+  void setLEDBit(uint8_t led, bool on);
+  void setRumbleBit(bool on);
+
+  ros::Publisher joy_pub_;
+  ros::Publisher imu_data_pub_;
+  ros::Publisher wiimote_state_pub_;
+  ros::Publisher wiimote_nunchuk_pub_;
+  ros::Publisher wiimote_classic_pub_;
+  ros::Publisher imu_is_calibrated_pub_;
+
+  ros::Subscriber joy_set_feedback_sub_;
+
+  ros::ServiceServer imu_calibrate_srv_;
+
+  // bluetooth device address
+  bdaddr_t bt_device_addr_;
+
+  // wiimote handle
+  wiimote_c::cwiid_wiimote_t *wiimote_;
+
+  // Last state of the Wiimote
+  struct wiimote_c::cwiid_state wiimote_state_;
+  void initializeWiimoteState();
+  // Time last state sample was taken
+  uint32_t state_secs_;
+  uint32_t state_nsecs_;
+
+  // Which data items should be reported in state
+  uint8_t report_mode_;
+
+  // Calibration status Wiimote
+  struct wiimote_c::acc_cal wiimote_cal_;  // wiimote acceleration factory calibration
+  bool wiimote_calibrated_;
+  ros::Time calibration_time_;
+
+  // Joystick related constants
+  const uint8_t JOYSTICK_NUNCHUK_DEFAULT_CENTER_ = 127;       // Theoretical center
+  const uint8_t JOYSTICK_NUNCHUK_20PERCENT_MAX_ = 205;
+  const uint8_t JOYSTICK_NUNCHUK_20PERCENT_MIN_ = 50;
+  const uint8_t JOYSTICK_CLASSIC_LEFT_DEFAULT_CENTER_ = 31;   // Theoretical center
+  const uint8_t JOYSTICK_CLASSIC_LEFT_20PERCENT_MAX_ = 50;
+  const uint8_t JOYSTICK_CLASSIC_LEFT_20PERCENT_MIN_ = 13;
+  const uint8_t JOYSTICK_CLASSIC_RIGHT_DEFAULT_CENTER_ = 15;  // Theoretical center
+  const uint8_t JOYSTICK_CLASSIC_RIGHT_20PERCENT_MAX_ = 25;
+  const uint8_t JOYSTICK_CLASSIC_RIGHT_20PERCENT_MIN_ = 6;
+
+  // Calibration status Nunchuk
+  struct wiimote_c::acc_cal nunchuk_cal_;  // nunchuk acceleration factory calibration
+  bool nunchuk_calibrated_;
+  bool nunchuk_failed_calibration_;
+  uint8_t nunchuk_stick_center_[2];  // nunchuk stick center position
+  bool nunchuk_stick_calibrated_;
+  uint8_t nunchuk_stick_max_[2];  // Maximums x,y
+  uint8_t nunchuk_stick_min_[2];  // Minimums x,y
+
+  // Calibration status Classic Controller
+  uint8_t classic_stick_left_center_[2];   // nunchuk stick center position
+  bool classic_stick_left_calibrated_;
+  uint8_t classic_stick_left_max_[2];
+  uint8_t classic_stick_left_min_[2];
+  uint8_t classic_stick_right_center_[2];  // nunchuk stick center position
+  bool classic_stick_right_calibrated_;
+  uint8_t classic_stick_right_max_[2];
+  uint8_t classic_stick_right_min_[2];
+
+  const int IGNORE_DATA_POINTS_ = 100;  // throw away the first few data points
+  const int COVARIANCE_DATA_POINTS_ = 100;
+  StatVector3d linear_acceleration_stat_;
+  StatVector3d angular_velocity_stat_;
+  boost::array<double, 9> linear_acceleration_covariance_;
+  boost::array<double, 9> angular_velocity_covariance_;
+
+  uint8_t led_state_ = 0;
+  uint8_t rumble_ = 0;
+
+  uint64_t wiimote_errors = 0;
+
+  // Convert wiimote accelerator readings from g's to m/sec^2:
+  const double EARTH_GRAVITY_ = 9.80665;  // m/sec^2 @sea_level
+
+  // Method used in Wiimote Python version
+  // TODO(mdhorn): Repeat experiment or create a new one
+  // and collect data from multiple wiimotes and use mean.
+  //
+  // Turning wiimote gyro readings to radians/sec.
+  // This scale factor is highly approximate. Procedure:
+  //    - Tape Wiimote to center of an office chair seat
+  //    - Rotate the chair at approximately constant speed
+  //      for 10 seconds. This resulted in 6 chair revolutions
+  //    - On average, the Wiimote gyro read 3570 during this
+  //      experiment.
+  //    - Speed of chair revolving:
+  //         * One full circle is: 2#pi radians
+  //         * Six revolutions = 12pi radians. ==> 12pi rad in 10 sec ==> 1.2pi rad/sec
+  //         * => 3570 == 1.2pi
+  //         * => x*3570 = 1.2pi
+  //         * => x = 1.2pi/3570 (1.2pi = 3.769908)
+  //         * => scale factor = 0.001055997
+  // So multiplying the gyro readings by this factor
+  // calibrates the readings to show angular velocity
+  // in radians/sec.
+  const double GYRO_SCALE_FACTOR_ = 0.001055997;
+};
+
+#endif  // WIIMOTE_WIIMOTE_CONTROLLER_H

--- a/wiimote/launch/feedback_test_cpp.launch
+++ b/wiimote/launch/feedback_test_cpp.launch
@@ -1,0 +1,14 @@
+<launch>
+  <node
+    pkg="wiimote"
+    type="feedbackTester.py"
+    name="test_harness"
+  />
+  <node
+    pkg="wiimote"
+    type="wiimote_node"
+    name="wiimote_controller"
+    output="screen"
+    required="true"
+  />
+</launch>

--- a/wiimote/launch/feedback_test_py.launch
+++ b/wiimote/launch/feedback_test_py.launch
@@ -1,0 +1,14 @@
+<launch>
+  <node
+    pkg="wiimote"
+    type="feedbackTester.py"
+    name="test_harness"
+  />
+  <node
+    pkg="wiimote"
+    type="wiimote_node.py"
+    name="wiimote_controller"
+    output="screen"
+    required="true"
+  />
+</launch>

--- a/wiimote/package.xml
+++ b/wiimote/package.xml
@@ -21,6 +21,7 @@
   <maintainer email="jbo@jhu.edu">Jonathan Bohren</maintainer>
   <author>Andreas Paepcke</author>
   <author>Melonee Wise</author>
+  <author email="mark.d.horn@intel.com">Mark Horn</author>
 
   <buildtool_depend>catkin</buildtool_depend>
   
@@ -28,23 +29,25 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>python-cwiid</build_depend>
+  <build_depend>cwiid-dev</build_depend>
   <build_depend>python-numpy</build_depend>
   <build_depend>roslib</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   
   <run_depend>genmsg</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>python-cwiid</run_depend>
+  <run_depend>cwiid</run_depend>
   <run_depend>python-numpy</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>roslib</run_depend>
-  <run_depend>python-numpy</run_depend>
-  <run_depend>python-cwiid</run_depend>
+  <run_depend>roscpp</run_depend>
 
   <export>
     <architecture_independent/>

--- a/wiimote/src/gpl-2.0.txt
+++ b/wiimote/src/gpl-2.0.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/wiimote/src/stat_vector_3d.cpp
+++ b/wiimote/src/stat_vector_3d.cpp
@@ -1,0 +1,175 @@
+/*
+ * Three dimensional statistic vector for use with the
+ * for ROS Node which interfaces with a wiimote control unit.
+ * Copyright (c) 2016, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+/*
+ * Initial C++ implementation by
+ *   Mark Horn <mark.d.horn@intel.com>
+ *
+ * Revisions:
+ *
+ */
+
+#include "wiimote/stat_vector_3d.h"
+
+#include "ros/ros.h"
+
+#include <numeric>
+#include <functional>
+#include <algorithm>
+#include <math.h>
+
+
+StatVector3d::StatVector3d()
+{
+  count_ = 0;
+}
+
+StatVector3d::StatVector3d(int x, int y, int z)
+{
+  count_ = 0;
+
+  addData(x, y, z);
+}
+
+void StatVector3d::clear()
+{
+  x_.clear();
+  y_.clear();
+  z_.clear();
+
+  count_ = 0;
+}
+
+int StatVector3d::size()
+{
+  return count_;
+}
+
+void StatVector3d::addData(int x, int y, int z)
+{
+  ++count_;
+
+  x_.push_back(x);
+  y_.push_back(y);
+  z_.push_back(z);
+}
+
+TVectorDouble StatVector3d::getMeanRaw()
+{
+  TVectorDouble result;
+
+  if (x_.size() < 1)
+  {
+    ROS_ERROR("StatVector3d:: Not enough data points for calculations!");
+    ros::Exception("Not enough data points for calculations");
+
+    return result;
+  }
+
+  double x_sum = std::accumulate(std::begin(x_), std::end(x_), 0.0);
+  result.push_back(x_sum / x_.size());
+
+  double y_sum = std::accumulate(std::begin(y_), std::end(y_), 0.0);
+  result.push_back(y_sum / y_.size());
+
+  double z_sum = std::accumulate(std::begin(z_), std::end(z_), 0.0);
+  result.push_back(z_sum / z_.size());
+
+  return result;
+}
+
+TVectorDouble StatVector3d::getMeanScaled(double scale)
+{
+  TVectorDouble mean = getMeanRaw();
+
+  std::transform(mean.begin(), mean.end(), mean.begin(),
+                     std::bind1st(std::multiplies<double>(), scale));
+
+  return mean;
+}
+
+TVectorDouble StatVector3d::getVarianceRaw()
+{
+  TVectorDouble result;
+
+  TVectorDouble mean = getMeanRaw();
+
+  if (x_.size() < 2)
+  {
+    ROS_ERROR("StatVector3d:: Not enough data points for calculations!");
+    ros::Exception("Not enough data points for calculations");
+
+    return result;
+  }
+
+  double accum = 0.0;
+  std::for_each(std::begin(x_), std::end(x_), [&](const double d)  // NOLINT(build/c++11)
+  {
+    accum += (d - mean.at(0)) * (d - mean.at(0));
+  });  // NOLINT(whitespace/braces)
+
+  result.push_back(accum / (x_.size()-1));
+
+  accum = 0.0;
+  std::for_each(std::begin(y_), std::end(y_), [&](const double d)  // NOLINT(build/c++11)
+  {
+    accum += (d - mean.at(1)) * (d - mean.at(1));
+  });  // NOLINT(whitespace/braces)
+
+  result.push_back(accum / (y_.size()-1));
+
+  accum = 0.0;
+  std::for_each(std::begin(z_), std::end(z_), [&](const double d)  // NOLINT(build/c++11)
+  {
+    accum += (d - mean.at(2)) * (d - mean.at(2));
+  });  // NOLINT(whitespace/braces)
+
+  result.push_back(accum / (z_.size()-1));
+
+  return result;
+}
+
+TVectorDouble StatVector3d::getVarianceScaled(double scale)
+{
+  TVectorDouble variance = getVarianceRaw();
+
+  std::transform(variance.begin(), variance.end(), variance.begin(),
+                     std::bind1st(std::multiplies<double>(), scale));
+
+  return variance;
+}
+
+TVectorDouble StatVector3d::getStandardDeviationRaw()
+{
+  TVectorDouble result;
+
+  TVectorDouble variance = getVarianceRaw();
+
+  result.push_back(sqrt(variance.at(0)));
+  result.push_back(sqrt(variance.at(1)));
+  result.push_back(sqrt(variance.at(2)));
+
+  return result;
+}
+
+TVectorDouble StatVector3d::getStandardDeviationScaled(double scale)
+{
+  TVectorDouble stddev = getStandardDeviationRaw();
+
+  std::transform(stddev.begin(), stddev.end(), stddev.begin(),
+                     std::bind1st(std::multiplies<double>(), scale));
+
+  return stddev;
+}

--- a/wiimote/src/wiimote_controller.cpp
+++ b/wiimote/src/wiimote_controller.cpp
@@ -1,0 +1,1621 @@
+/*
+ * ROS Node for interfacing with a wiimote control unit.
+ * Copyright (c) 2016, Intel Corporation.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+/*
+ * This code is based on the original Python implementation
+ * created by Andreas Paepcke and Melonee Wise
+ *  Andreas Paepcke <paepcke@anw.willowgarage.com>
+ * with contributions by
+ *  David Lu <davidlu@wustl.edu>
+ *  Miguel Angel Julian Aguilar <miguel.angel@thecorpora.com>
+ * See https://github.com/ros-drivers/joystick_drivers/tree/indigo-devel/wiimote
+ * for details and history.
+ *
+ * This C++ implementation used the functionality of the existing
+ * Python code as the feature requirements.
+ */
+
+/*
+ * Initial C++ implementation by
+ *   Mark Horn <mark.d.horn@intel.com>
+ *
+ * The C++ implementation was designed with focus on reduced resource consumption.
+ *
+ * Differences from Python implementation:
+ * - Both "/wiimote/nunchuk" and "/wiimote/classic" topics are only published
+ *   if the Nunchuk or Classic Controller are connected to the wiimote respectively.
+ * - Wiimote data is only polled from the controller if the data is required
+ *   to publish for a topic which has at least one subscriber.
+ *
+ * Revisions:
+ *
+ */
+
+#include "wiimote/wiimote_controller.h"
+
+#include "sensor_msgs/Joy.h"
+#include "std_msgs/Bool.h"
+
+#include "wiimote/State.h"
+#include "wiimote/IrSourceInfo.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <signal.h>
+
+#include <time.h>
+#include <math.h>
+
+#include <vector>
+
+WiimoteNode::WiimoteNode()
+{
+  joy_pub_ = nh_.advertise<sensor_msgs::Joy>("/joy", 1);
+  imu_data_pub_ = nh_.advertise<sensor_msgs::Imu>("/imu/data", 1);
+  wiimote_state_pub_ = nh_.advertise<wiimote::State>("/wiimote/state", 1);
+  /**
+   * Optional Publications -- only advertise if the hardware is connected
+   * This is done in the main loop in the ::publish method
+   * wiimote_nunchuk_pub_ = nh_.advertise<sensor_msgs::Joy>("/wiimote/nunchuk", 1);
+   * wiimote_classic_pub_ = nh_.advertise<sensor_msgs::Joy>("/wiimote/classic", 1);
+   **/
+  imu_is_calibrated_pub_ = nh_.advertise<std_msgs::Bool>("/imu/is_calibrated", 1, true);
+
+  joy_set_feedback_sub_ = nh_.subscribe<sensor_msgs::JoyFeedbackArray>("/joy/set_feedback", 10,
+      &WiimoteNode::joySetFeedbackCallback, this);
+
+  imu_calibrate_srv_ = nh_.advertiseService("/imu/calibrate", &WiimoteNode::serviceImuCalibrateCallback, this);
+
+  // Initialize with the ANY Bluetooth Address
+  setBluetoothAddr("00:00:00:00:00:00");
+
+  wiimote_ = nullptr;
+
+  initializeWiimoteState();
+
+  state_secs_ = 0;
+  state_nsecs_ = 0;
+
+  // Setup the Wii Error Handler
+  wiimote_c::cwiid_set_err(cwiidErrorCallback);
+
+  report_mode_ = 0;
+
+  wiimote_calibrated_ = false;
+
+  resetMotionPlusState();
+  resetNunchukState();
+  resetClassicState();
+  nunchuk_failed_calibration_ = false;
+}
+
+WiimoteNode::~WiimoteNode()
+{
+}
+
+void WiimoteNode::initializeWiimoteState()
+{
+  wiimote_state_.rpt_mode = 0;
+  wiimote_state_.led = 0;
+  wiimote_state_.rumble = 0;
+  wiimote_state_.battery = 0;
+  wiimote_state_.buttons = 0;
+  wiimote_state_.acc[0] = 0;
+  wiimote_state_.acc[1] = 0;
+  wiimote_state_.acc[2] = 0;
+
+  wiimote_state_.ext_type = wiimote_c::CWIID_EXT_NONE;
+  wiimote_state_.error = wiimote_c::CWIID_ERROR_NONE;
+
+  wiimote_state_.ir_src[0].valid = 0;
+  wiimote_state_.ir_src[1].valid = 0;
+  wiimote_state_.ir_src[2].valid = 0;
+  wiimote_state_.ir_src[3].valid = 0;
+  wiimote_state_.ir_src[0].pos[0] = 0; wiimote_state_.ir_src[0].pos[1] = 0;
+  wiimote_state_.ir_src[1].pos[0] = 0; wiimote_state_.ir_src[1].pos[1] = 0;
+  wiimote_state_.ir_src[2].pos[0] = 0; wiimote_state_.ir_src[2].pos[1] = 0;
+  wiimote_state_.ir_src[3].pos[0] = 0; wiimote_state_.ir_src[3].pos[1] = 0;
+  wiimote_state_.ir_src[0].size = 0;
+  wiimote_state_.ir_src[1].size = 0;
+  wiimote_state_.ir_src[2].size = 0;
+  wiimote_state_.ir_src[3].size = 0;
+}
+
+char *WiimoteNode::getBluetoothAddr()
+{
+  return batostr(&bt_device_addr_);
+}
+void WiimoteNode::setBluetoothAddr(const char *bt_str)
+{
+  str2ba(bt_str, &bt_device_addr_);
+}
+
+bool WiimoteNode::pairWiimote(int flags = 0, int timeout = 5)
+{
+  bool status = true;
+
+  ROS_INFO("Put Wiimote in discoverable mode now (press 1+2)...");
+  ROS_INFO("Timeout in about %d seconds if not paired.", timeout);
+
+  if (!(wiimote_ = wiimote_c::cwiid_open_timeout(&bt_device_addr_, flags, timeout)))
+  {
+    ROS_ERROR("Unable to connect to wiimote");
+    status = false;
+  }
+  else
+  {
+    // Give the hardware time to zero the accelerometer and gyro after pairing
+    // Ensure we are getting valid data before using
+    sleep(1);
+
+    checkFactoryCalibrationData();
+
+    if (!wiimote_calibrated_)
+    {
+      ROS_ERROR("Wiimote not usable due to calibration failure.");
+      status = false;
+    }
+  }
+
+  return status;
+}
+int WiimoteNode::unpairWiimote()
+{
+  return wiimote_c::cwiid_close(wiimote_);
+}
+
+void WiimoteNode::checkFactoryCalibrationData()
+{
+  bool result = true;
+
+  if (wiimote_c::cwiid_get_acc_cal(wiimote_, wiimote_c::CWIID_EXT_NONE, &wiimote_cal_) != 0)
+  {
+    if (wiimote_calibrated_)
+    {
+      ROS_WARN("Failed to read current Wiimote calibration data; proceeding with previous data");
+    }
+    else
+    {
+      ROS_ERROR("Failed to read Wiimote factory calibration data");
+      result = false;
+    }
+  }
+  else
+  {
+    // If any calibration point is zero; we fail
+    if (!(wiimote_cal_.zero[CWIID_X] && wiimote_cal_.zero[CWIID_Y] && wiimote_cal_.zero[CWIID_Z] &&
+        wiimote_cal_.one[CWIID_X] && wiimote_cal_.one[CWIID_Y] && wiimote_cal_.one[CWIID_Z]))
+    {
+      ROS_ERROR("Some Wiimote factory calibration data is missing; calibration failed");
+      ROS_ERROR("Wiimote Cal:: zero[x]:%d, zero[y]:%d, zero[z]:%d,\n\tone[x]:%d, one[y]:%d, one[z]:%d",
+          wiimote_cal_.zero[CWIID_X], wiimote_cal_.zero[CWIID_Y], wiimote_cal_.zero[CWIID_Z],
+          wiimote_cal_.one[CWIID_X], wiimote_cal_.one[CWIID_Y], wiimote_cal_.one[CWIID_Z]);
+
+      result = false;
+    }
+    else
+    {
+      wiimote_calibrated_ = true;
+      ROS_DEBUG("Wiimote Cal:: zero[x]:%d, zero[y]:%d, zero[z]:%d,\n\tone[x]:%d, one[y]:%d, one[z]:%d",
+          wiimote_cal_.zero[CWIID_X], wiimote_cal_.zero[CWIID_Y], wiimote_cal_.zero[CWIID_Z],
+          wiimote_cal_.one[CWIID_X], wiimote_cal_.one[CWIID_Y], wiimote_cal_.one[CWIID_Z]);
+    }
+  }
+
+  if (!getStateSample())
+  {
+    ROS_WARN("Could not read Wiimote state; nunchuk may not be calibrated if present.");
+  }
+  else
+  {
+    if (isPresentNunchuk())
+    {
+      if (wiimote_c::cwiid_get_acc_cal(wiimote_, wiimote_c::CWIID_EXT_NUNCHUK, &nunchuk_cal_) != 0)
+      {
+        if (nunchuk_calibrated_)
+        {
+          ROS_WARN("Failed to read current Nunchuk calibration data; proceeding with previous data");
+        }
+        else
+        {
+          ROS_ERROR("Failed to read Nunchuk factory calibration data");
+          result = false;
+          nunchuk_failed_calibration_ = true;
+        }
+      }
+      else
+      {
+        // If any calibration point is zero; we fail
+        if (!(nunchuk_cal_.zero[CWIID_X] && nunchuk_cal_.zero[CWIID_Y] && nunchuk_cal_.zero[CWIID_Z] &&
+            nunchuk_cal_.one[CWIID_X] && nunchuk_cal_.one[CWIID_Y] && nunchuk_cal_.one[CWIID_Z]))
+        {
+          ROS_ERROR("Some Nunchuk factory calibration data is missing; calibration failed");
+          ROS_ERROR("Nunchuk Cal:: zero[x]:%d, zero[y]:%d, zero[z]:%d,\n\tone[x]:%d, one[y]:%d, one[z]:%d",
+              nunchuk_cal_.zero[CWIID_X], nunchuk_cal_.zero[CWIID_Y], nunchuk_cal_.zero[CWIID_Z],
+              nunchuk_cal_.one[CWIID_X], nunchuk_cal_.one[CWIID_Y], nunchuk_cal_.one[CWIID_Z]);
+          result = false;
+          nunchuk_failed_calibration_ = true;
+        }
+        else
+        {
+          nunchuk_calibrated_ = true;
+          ROS_DEBUG("Nunchuk Cal:: zero[x]:%d, zero[y]:%d, zero[z]:%d,\n\tone[x]:%d, one[y]:%d, one[z]:%d",
+              nunchuk_cal_.zero[CWIID_X], nunchuk_cal_.zero[CWIID_Y], nunchuk_cal_.zero[CWIID_Z],
+              nunchuk_cal_.one[CWIID_X], nunchuk_cal_.one[CWIID_Y], nunchuk_cal_.one[CWIID_Z]);
+        }
+      }
+    }
+  }
+
+  if (wiimote_calibrated_)
+  {
+    // Save the current reporting mode
+    uint8_t save_report_mode = wiimote_state_.rpt_mode;
+
+    // Need to ensure we are collecting accelerometer
+    uint8_t new_report_mode = save_report_mode | (CWIID_RPT_ACC | CWIID_RPT_EXT);
+
+    if (new_report_mode != save_report_mode)
+    {
+      setReportMode(new_report_mode);
+    }
+
+    ROS_INFO("Collecting additional calibration data; keep wiimote stationary...");
+
+    StatVector3d linear_acceleration_stat_old = linear_acceleration_stat_;
+    linear_acceleration_stat_.clear();
+    StatVector3d angular_velocity_stat_old = angular_velocity_stat_;
+    angular_velocity_stat_.clear();
+
+    bool failed = false;
+    bool data_complete = false;
+    int wiimote_data_points = 0;
+    int motionplus_data_points = 0;
+
+    while (!failed && !data_complete)
+    {
+      if (getStateSample())
+      {
+        if (wiimote_data_points < COVARIANCE_DATA_POINTS_)
+        {
+          linear_acceleration_stat_.addData(
+              wiimote_state_.acc[CWIID_X],
+              wiimote_state_.acc[CWIID_Y],
+              wiimote_state_.acc[CWIID_Z]);
+
+          ++wiimote_data_points;
+        }
+
+        if (isPresentMotionplus())
+        {
+          if (motionplus_data_points < COVARIANCE_DATA_POINTS_)
+          {
+            // ROS_DEBUG("New MotionPlus data :%03d: PHI: %04d, THETA: %04d, PSI: %04d", motionplus_data_points,
+            //     wiimote_state_.ext.motionplus.angle_rate[CWIID_PHI],
+            //     wiimote_state_.ext.motionplus.angle_rate[CWIID_THETA],
+            //     wiimote_state_.ext.motionplus.angle_rate[CWIID_PSI]);
+            angular_velocity_stat_.addData(
+                wiimote_state_.ext.motionplus.angle_rate[CWIID_PHI],
+                wiimote_state_.ext.motionplus.angle_rate[CWIID_THETA],
+                wiimote_state_.ext.motionplus.angle_rate[CWIID_PSI]);
+
+            ++motionplus_data_points;
+          }
+        }
+      }
+      else
+      {
+        failed = true;
+      }
+
+      if (wiimote_data_points >= COVARIANCE_DATA_POINTS_)
+      {
+        if (!isPresentMotionplus())
+        {
+          data_complete = true;
+        }
+        else
+        {
+          if (motionplus_data_points >= COVARIANCE_DATA_POINTS_)
+          {
+            data_complete = true;
+          }
+        }
+      }
+    }
+
+    if (!failed)
+    {
+      ROS_DEBUG("Calculating calibration data...");
+
+      // Check the standard deviations > 1.0
+      TVectorDouble stddev = linear_acceleration_stat_.getStandardDeviationRaw();
+      bool is_bad_cal = false;
+      std::for_each(std::begin(stddev), std::end(stddev), [&](const double d)  // NOLINT(build/c++11)
+      {
+        if (d > 1.0)
+        {
+          is_bad_cal = true;
+          ROS_DEBUG("Wiimote standard deviation > 1.0");
+        }
+      });  // NOLINT(whitespace/braces)
+
+      if (!is_bad_cal)
+      {
+        TVectorDouble variance = linear_acceleration_stat_.getVarianceScaled(EARTH_GRAVITY_);
+
+        ROS_DEBUG("Variance Scaled x: %lf, y: %lf, z: %lf", variance.at(CWIID_X),
+            variance.at(CWIID_Y), variance.at(CWIID_Z));
+
+        linear_acceleration_covariance_[0] = variance.at(CWIID_X);
+        linear_acceleration_covariance_[1] = 0.0;
+        linear_acceleration_covariance_[2] = 0.0;
+
+        linear_acceleration_covariance_[3] = 0.0;
+        linear_acceleration_covariance_[4] = variance.at(CWIID_Y);
+        linear_acceleration_covariance_[5] = 0.0;
+
+        linear_acceleration_covariance_[6] = 0.0;
+        linear_acceleration_covariance_[7] = 0.0;
+        linear_acceleration_covariance_[8] = variance.at(CWIID_Z);
+      }
+      else
+      {
+        ROS_ERROR("Failed calibration; using questionable data for linear acceleration");
+
+        linear_acceleration_stat_ = linear_acceleration_stat_old;
+        angular_velocity_stat_ = angular_velocity_stat_old;
+
+        result = false;
+      }
+
+      if (angular_velocity_stat_.size() == COVARIANCE_DATA_POINTS_)
+      {
+        // Check the standard deviations > 50.0
+        TVectorDouble gyro_stddev = angular_velocity_stat_.getStandardDeviationRaw();
+        std::for_each(std::begin(gyro_stddev), std::end(gyro_stddev), [&](const double d)  // NOLINT(build/c++11)
+        {
+          if (d > 50.0)
+          {
+            is_bad_cal = true;
+            ROS_DEBUG("MotionPlus standard deviation > 50");
+          }
+        });  // NOLINT(whitespace/braces)
+
+        if (!is_bad_cal)
+        {
+          TVectorDouble gyro_variance = angular_velocity_stat_.getVarianceScaled(GYRO_SCALE_FACTOR_);
+
+          ROS_DEBUG("Gyro Variance Scaled x: %lf, y: %lf, z: %lf", gyro_variance.at(CWIID_PHI),
+              gyro_variance.at(CWIID_THETA), gyro_variance.at(CWIID_PSI));
+
+          angular_velocity_covariance_[0] = gyro_variance.at(CWIID_PHI);
+          angular_velocity_covariance_[1] = 0.0;
+          angular_velocity_covariance_[2] = 0.0;
+
+          angular_velocity_covariance_[3] = 0.0;
+          angular_velocity_covariance_[4] = gyro_variance.at(CWIID_THETA);
+          angular_velocity_covariance_[5] = 0.0;
+
+          angular_velocity_covariance_[6] = 0.0;
+          angular_velocity_covariance_[7] = 0.0;
+          angular_velocity_covariance_[8] = gyro_variance.at(CWIID_PSI);
+        }
+        else
+        {
+          ROS_ERROR("Failed calibration; using questionable data for angular velocity");
+
+          angular_velocity_stat_ = angular_velocity_stat_old;
+
+          result = false;
+        }
+      }
+      else
+      {
+        resetMotionPlusState();
+      }
+    }
+
+    if (failed)
+    {
+      ROS_ERROR("Failed calibration; using questionable data");
+      result = false;
+    }
+    else
+    {
+      struct timespec state_tv;
+
+      if (clock_gettime(CLOCK_REALTIME, &state_tv) == 0)
+      {
+        calibration_time_ = ros::Time::now();
+      }
+      else
+      {
+        ROS_WARN("Could not update calibration time.");
+      }
+    }
+
+    // Restore the pre-existing reporting mode
+    if (new_report_mode != save_report_mode)
+    {
+      setReportMode(save_report_mode);
+    }
+  }
+
+  // Publish the initial calibration state
+  std_msgs::Bool imu_is_calibrated_data;
+  imu_is_calibrated_data.data = result;
+  imu_is_calibrated_pub_.publish(imu_is_calibrated_data);
+}
+
+void WiimoteNode::resetMotionPlusState()
+{
+  // If no gyro is attached to the Wiimote then we signal
+  // the invalidity of angular rate with a covariance matrix
+  // whose first element is -1:
+  angular_velocity_covariance_[0] = -1.0;
+  angular_velocity_covariance_[1] = 0.0;
+  angular_velocity_covariance_[2] = 0.0;
+
+  angular_velocity_covariance_[3] = 0.0;
+  angular_velocity_covariance_[4] = 0.0;
+  angular_velocity_covariance_[5] = 0.0;
+
+  angular_velocity_covariance_[6] = 0.0;
+  angular_velocity_covariance_[7] = 0.0;
+  angular_velocity_covariance_[8] = 0.0;
+}
+
+void WiimoteNode::resetNunchukState()
+{
+  nunchuk_calibrated_ = false;
+
+  nunchuk_stick_calibrated_ = false;
+  nunchuk_stick_center_[CWIID_X] = JOYSTICK_NUNCHUK_DEFAULT_CENTER_;
+  nunchuk_stick_center_[CWIID_Y] = JOYSTICK_NUNCHUK_DEFAULT_CENTER_;
+  nunchuk_stick_max_[CWIID_X] = JOYSTICK_NUNCHUK_20PERCENT_MAX_;
+  nunchuk_stick_max_[CWIID_Y] = JOYSTICK_NUNCHUK_20PERCENT_MAX_;
+  nunchuk_stick_min_[CWIID_X] = JOYSTICK_NUNCHUK_20PERCENT_MIN_;
+  nunchuk_stick_min_[CWIID_Y] = JOYSTICK_NUNCHUK_20PERCENT_MIN_;
+}
+
+void WiimoteNode::resetClassicState()
+{
+  classic_stick_left_calibrated_ = false;
+  classic_stick_right_calibrated_ = false;
+  classic_stick_left_center_[CWIID_X] = JOYSTICK_CLASSIC_LEFT_DEFAULT_CENTER_;
+  classic_stick_left_center_[CWIID_Y] = JOYSTICK_CLASSIC_LEFT_DEFAULT_CENTER_;
+  classic_stick_right_center_[CWIID_X] = JOYSTICK_CLASSIC_RIGHT_DEFAULT_CENTER_;
+  classic_stick_right_center_[CWIID_Y] = JOYSTICK_CLASSIC_RIGHT_DEFAULT_CENTER_;
+  classic_stick_left_max_[CWIID_X] = JOYSTICK_CLASSIC_LEFT_20PERCENT_MAX_;
+  classic_stick_left_max_[CWIID_Y] = JOYSTICK_CLASSIC_LEFT_20PERCENT_MAX_;
+  classic_stick_left_min_[CWIID_X] = JOYSTICK_CLASSIC_LEFT_20PERCENT_MIN_;
+  classic_stick_left_min_[CWIID_Y] = JOYSTICK_CLASSIC_LEFT_20PERCENT_MIN_;
+  classic_stick_right_max_[CWIID_X] = JOYSTICK_CLASSIC_RIGHT_20PERCENT_MAX_;
+  classic_stick_right_max_[CWIID_Y] = JOYSTICK_CLASSIC_RIGHT_20PERCENT_MAX_;
+  classic_stick_right_min_[CWIID_X] = JOYSTICK_CLASSIC_RIGHT_20PERCENT_MIN_;
+  classic_stick_right_min_[CWIID_Y] = JOYSTICK_CLASSIC_RIGHT_20PERCENT_MIN_;
+}
+
+void WiimoteNode::publish()
+{
+  uint8_t joy_subscribers = joy_pub_.getNumSubscribers();
+  uint8_t wii_state_subscribers = wiimote_state_pub_.getNumSubscribers();
+  uint8_t imu_subscribers = imu_data_pub_.getNumSubscribers();
+  uint8_t wii_nunchuk_subscribers = 0;
+  uint8_t wii_classic_subscribers = 0;
+
+  uint8_t current_report_mode = wiimote_state_.rpt_mode;
+  uint8_t new_report_mode = current_report_mode;
+
+  /*              CWIID_RPT_xxx
+
+                  | | | |M| | |
+                  | | | |O| | |
+                  | | | |T| | |
+                  | | | |I|N|C|
+                  | | | |O|U|L|
+                  | | | |N|N|A|
+                  | | | |P|C|S|
+                  | |B|A|L|H|S|
+                  |I|T|C|U|U|I|
+  ROS_Topic       |R|N|C|S|K|C|
+                  |_|_|_|_|_|_|
+  joy             | |x|x|x| | |
+  imu_data        | | |x|x| | |
+  wiimote_state   |x|x|x|x|x| |
+  wiimote_nunchuk | | | | |x| |
+  wiimote_classic | | | | | |x|
+  */
+
+  if (joy_subscribers || wii_state_subscribers || imu_subscribers)
+  {
+    // Need to collect data on accelerometer and motionplus
+    new_report_mode |= (CWIID_RPT_ACC | CWIID_RPT_MOTIONPLUS);
+
+    if (joy_subscribers || wii_state_subscribers)
+    {
+      // Need to also collect data on buttons
+      new_report_mode |= (CWIID_RPT_BTN);
+    }
+
+    if (wii_state_subscribers)
+    {
+      // Need to also collect data on IR and Nunchuk
+      new_report_mode |= (CWIID_RPT_IR | CWIID_RPT_NUNCHUK);
+    }
+  }
+  else
+  {
+    if (!joy_subscribers && !wii_state_subscribers && !imu_subscribers)
+    {
+      // Can stop collecting data on accelerometer and motionplus
+      new_report_mode &= ~(CWIID_RPT_ACC | CWIID_RPT_MOTIONPLUS);
+    }
+
+    if (!joy_subscribers && !wii_state_subscribers)
+    {
+      // Can also stop collecting data on buttons
+      new_report_mode &= ~(CWIID_RPT_BTN);
+    }
+
+    if (!wii_state_subscribers)
+    {
+      // Can also stop collecting data on IR
+      new_report_mode &= ~(CWIID_RPT_IR);
+    }
+  }
+
+  // Is the Nunchuk connected?
+  if (isPresentNunchuk())
+  {
+    // Is the Nunchuk publisher not advertised?
+    if (nullptr == wiimote_nunchuk_pub_)
+    {
+      if (!nunchuk_failed_calibration_)
+      {
+        // The nunchuk was just connected, so read the calibration data
+        if (!nunchuk_calibrated_)
+        {
+          checkFactoryCalibrationData();
+        }
+
+        if (nunchuk_calibrated_)
+        {
+          wiimote_nunchuk_pub_ = nh_.advertise<sensor_msgs::Joy>("/wiimote/nunchuk", 1);
+        }
+        else
+        {
+          ROS_ERROR("Topic /wiimote/nunchuk not advertised due to calibration failure");
+        }
+      }
+    }
+
+    wii_nunchuk_subscribers = wiimote_nunchuk_pub_.getNumSubscribers();
+
+    if (wii_nunchuk_subscribers)
+    {
+      // Need to collect data on nunchuk
+      new_report_mode |= (CWIID_RPT_NUNCHUK);
+    }
+    else
+    {
+      if (!wii_state_subscribers)
+      {
+        // Can stop collecting data on nunchuk
+        new_report_mode &= ~(CWIID_RPT_NUNCHUK);
+      }
+    }
+  }
+  else  // Stop publishing the topic
+  {
+    // Is the Nunchuk publisher advertised?
+    if (nullptr != wiimote_nunchuk_pub_)
+    {
+      wiimote_nunchuk_pub_.shutdown();
+
+      resetNunchukState();
+
+      if (!wii_state_subscribers)
+      {
+        // Can stop collecting data on nunchuk
+        new_report_mode &= ~(CWIID_RPT_NUNCHUK);
+      }
+    }
+
+    // If the nunchuk was connect, but failed calibration
+    // then attempt to check factory calibration for the wiimote
+    if (nunchuk_failed_calibration_)
+    {
+      checkFactoryCalibrationData();
+      nunchuk_failed_calibration_ = false;
+    }
+  }
+
+  // Is the Classic Pad connected?
+  if (isPresentClassic())
+  {
+    // Is the Classic Pad publisher not advertised?
+    if (nullptr == wiimote_classic_pub_)
+    {
+      wiimote_classic_pub_ = nh_.advertise<sensor_msgs::Joy>("/wiimote/classic", 1);
+    }
+
+    wii_classic_subscribers = wiimote_classic_pub_.getNumSubscribers();
+
+    if (wii_classic_subscribers)
+    {
+      // Need to collect data on classic
+      new_report_mode |= (CWIID_RPT_CLASSIC);
+    }
+    else
+    {
+      // Can stop collecting data on classic
+      new_report_mode &= ~(CWIID_RPT_CLASSIC);
+    }
+  }
+  else  // Stop publishing the topic
+  {
+    // Is the Classic Pad publisher advertised?
+    if (nullptr != wiimote_classic_pub_)
+    {
+      wiimote_classic_pub_.shutdown();
+
+      resetClassicState();
+
+      // Can stop collecting data on classic
+      new_report_mode &= ~(CWIID_RPT_CLASSIC);
+    }
+  }
+
+  // Update the reporting mode and returning
+  if (current_report_mode != new_report_mode)
+  {
+    setReportMode(new_report_mode);
+  }
+
+  if (!joy_subscribers && !wii_state_subscribers && !imu_subscribers &&
+      !wii_nunchuk_subscribers & !wii_classic_subscribers)
+  {
+    // If there are no subscribers, there isn't anything to publish
+    return;
+  }
+
+
+  if (!getStateSample())
+  {
+    // If we can not get State from the Wiimote, there isn't anything to publish
+    return;
+  }
+
+
+  if (joy_subscribers)
+  {
+    // ROS_DEBUG("Number joy subscribers is: %d", joy_subscribers);
+    publishJoy();
+  }
+
+  if (imu_subscribers)
+  {
+    // ROS_DEBUG("Number imu_data subscribers is: %d", imu_subscribers);
+    publishImuData();
+  }
+
+  if (wii_state_subscribers)
+  {
+    // ROS_DEBUG("Number wiimote_state subscribers is: %d", wii_state_subscribers);
+    publishWiimoteState();
+  }
+
+  if (wii_nunchuk_subscribers)
+  {
+    // ROS_DEBUG("Number wiimote_nunchuk subscribers is: %d", wiimote_nunchuk_pub_.getNumSubscribers());
+    publishWiimoteNunchuk();
+  }
+
+  // Is the Classic Pad connected?
+  if (wii_classic_subscribers)
+  {
+    // ROS_DEBUG("Number wiimote_classic subscribers is: %d", wiimote_classic_pub_.getNumSubscribers());
+    publishWiimoteClassic();
+  }
+}
+
+bool WiimoteNode::getStateSample()
+{
+  bool result = true;
+  bool get_state_result = true;
+  bool data_valid = false;
+
+  int count = 0;
+  int big_count = 0;
+  static int wiimote_count = 0;
+  static int motionplus_count = 0;
+
+  do
+  {
+    get_state_result = (wiimote_c::cwiid_get_state(wiimote_, &wiimote_state_) == 0);
+
+    if (isCollectingWiimote() &&
+        (wiimote_state_.acc[CWIID_X] == 0 &&
+         wiimote_state_.acc[CWIID_Y] == 0 &&
+         wiimote_state_.acc[CWIID_Z] == 0))
+    {
+      if (count > 1 && !(count % 100))
+      {
+        // If we can not get valid data from the Wiimote, wait and try again
+        ROS_INFO("Waiting for valid wiimote data...");
+        count = 0;
+        ++big_count;
+      }
+
+      usleep(10000);  // wait a hundredth of a second
+      ++count;
+      if (big_count > 10)
+      {
+        get_state_result = false;
+      }
+    }
+    else
+    {
+      if (wiimote_count < IGNORE_DATA_POINTS_)
+      {
+        // ROS_DEBUG("Ignoring Wiimote data point %d", wiimote_count);
+        wiimote_count++;
+      }
+      else
+      {
+        data_valid = true;
+      }
+    }
+
+    usleep(10000);  // wait a hundredth of a second
+  }
+  while (get_state_result && !data_valid);
+
+  if (isPresentMotionplus())
+  {
+    data_valid = false;
+
+    count = 0;
+    big_count = 0;
+
+    do
+    {
+      if (wiimote_state_.ext.motionplus.angle_rate[CWIID_PHI] == 0 &&
+          wiimote_state_.ext.motionplus.angle_rate[CWIID_THETA] == 0 &&
+          wiimote_state_.ext.motionplus.angle_rate[CWIID_PSI] == 0)
+      {
+        if (count > 1 && !(count % 100))
+        {
+          // If we can not get valid data from the Wiimote, wait and try again
+          ROS_INFO("Waiting for valid MotionPlus data...");
+          count = 0;
+          ++big_count;
+        }
+
+        usleep(10000);  // wait a hundredth of a second
+        ++count;
+        if (big_count > 10)
+        {
+          get_state_result = false;
+        }
+        else
+        {
+          usleep(10000);  // wait a hundredth of a second
+          get_state_result = (wiimote_c::cwiid_get_state(wiimote_, &wiimote_state_) == 0);
+        }
+      }
+      else
+      {
+        if (motionplus_count < IGNORE_DATA_POINTS_)
+        {
+          ROS_DEBUG("Ignoring MotionPlus data point %d", motionplus_count);
+          motionplus_count++;
+          usleep(1000);  // wait a thousandth of a second
+        }
+        else
+        {
+          data_valid = true;
+          // Get a new data point with valid data
+          get_state_result = (wiimote_c::cwiid_get_state(wiimote_, &wiimote_state_) == 0);
+        }
+      }
+    }
+    while (get_state_result && !data_valid);
+  }
+  else
+  {
+    // MotionPlus was removed, so reset the master count
+    motionplus_count = 0;
+    resetMotionPlusState();
+  }
+
+  if (get_state_result)
+  {
+    struct timespec state_tv;
+
+    if (clock_gettime(CLOCK_REALTIME, &state_tv) == 0)
+    {
+      state_secs_ = state_tv.tv_sec;
+      state_nsecs_ = state_tv.tv_nsec;
+    }
+    else
+    {
+      ROS_ERROR("Error sampling real-time clock");
+      result = false;
+    }
+  }
+  else
+  {
+    result = false;
+  }
+
+  return result;
+}
+
+void WiimoteNode::setReportMode(uint8_t rpt_mode)
+{
+  ROS_DEBUG("Change report mode from %d to %d", wiimote_state_.rpt_mode, rpt_mode);
+
+  if (wiimote_c::cwiid_set_rpt_mode(wiimote_, rpt_mode))
+  {
+    ROS_ERROR("Error setting report mode: Bit(s):%d", rpt_mode);
+  }
+  else
+  {
+    wiimote_state_.rpt_mode = rpt_mode;
+
+    // Enable the MotionPlus
+    if (rpt_mode & CWIID_RPT_MOTIONPLUS)
+    {
+      wiimote_c::cwiid_enable(wiimote_, CWIID_FLAG_MOTIONPLUS);
+      ROS_DEBUG("Enabled MotionPlus");
+    }
+  }
+}
+
+void WiimoteNode::setLEDBit(uint8_t led, bool on)
+{
+  uint8_t bit;
+
+  if (led > 3)
+  {
+    ROS_WARN("LED ID %d out of bounds; ignoring!", led);
+  }
+
+  bit = 1 << led;
+
+  if (on)
+  {  // Set bit
+    led_state_ |= bit;
+  }
+  else
+  {  // Clear bit
+    led_state_ &= ~(bit);
+  }
+}
+void WiimoteNode::setRumbleBit(bool on)
+{
+  if (on)
+  {  // Set bit
+    rumble_ |= 0x1;
+  }
+  else
+  {  // Clear bit
+    rumble_ &= ~(0x1);
+  }
+}
+
+void WiimoteNode::setLedState(uint8_t led_state)
+{
+  if (wiimote_c::cwiid_set_led(wiimote_, led_state))
+  {
+    ROS_ERROR("Error setting LEDs");
+  }
+}
+
+void WiimoteNode::setRumbleState(uint8_t rumble)
+{
+  if (wiimote_c::cwiid_set_rumble(wiimote_, rumble))
+  {
+    ROS_ERROR("Error setting rumble");
+  }
+}
+
+void WiimoteNode::cwiidErrorCallback(wiimote_c::cwiid_wiimote_t *wiimote, const char *fmt, va_list ap)
+{
+  const int MAX_BUF = 500;
+  char msgs_buf[MAX_BUF];
+
+  vsnprintf(msgs_buf, MAX_BUF, fmt, ap);
+
+  if (wiimote)
+  {
+    ROS_ERROR("Wii Error: ID: %d: %s", wiimote_c::cwiid_get_id(wiimote), msgs_buf);
+  }
+  else
+  {
+    ROS_ERROR("Wii Error: ID: ?: %s", msgs_buf);
+  }
+}
+
+bool WiimoteNode::isCollectingWiimote()
+{
+  return wiimote_state_.rpt_mode &
+    (CWIID_RPT_BTN | CWIID_RPT_ACC | CWIID_RPT_IR);
+}
+bool WiimoteNode::isCollectingNunchuk()
+{
+  return wiimote_state_.rpt_mode & CWIID_RPT_NUNCHUK;
+}
+bool WiimoteNode::isCollectingClassic()
+{
+  return wiimote_state_.rpt_mode & CWIID_RPT_CLASSIC;
+}
+bool WiimoteNode::isCollectingMotionplus()
+{
+  return wiimote_state_.rpt_mode & CWIID_RPT_MOTIONPLUS;
+}
+
+bool WiimoteNode::isPresentNunchuk()
+{
+  return wiimote_state_.ext_type == wiimote_c::CWIID_EXT_NUNCHUK;
+}
+bool WiimoteNode::isPresentClassic()
+{
+  return wiimote_state_.ext_type == wiimote_c::CWIID_EXT_CLASSIC;
+}
+bool WiimoteNode::isPresentMotionplus()
+{
+  return wiimote_state_.ext_type == wiimote_c::CWIID_EXT_MOTIONPLUS;
+}
+
+bool WiimoteNode::calibrateJoystick(uint8_t stick[2], uint8_t (&center)[2], const char *name)
+{
+  bool is_calibrated = false;
+
+  // Grab the current Joystick position as center
+  // If it is not reporting 0, 0
+  if (stick[CWIID_X] != 0 && stick[CWIID_Y] != 0)
+  {
+    center[CWIID_X] = stick[CWIID_X];
+    center[CWIID_Y] = stick[CWIID_Y];
+
+    is_calibrated = true;
+
+    ROS_DEBUG("%s Joystick Center:: x:%d, y:%d", name, center[CWIID_X], center[CWIID_Y]);
+  }
+
+  return is_calibrated;
+}
+
+void WiimoteNode::updateJoystickMinMax(uint8_t stick[2], uint8_t (&stick_min)[2],
+    uint8_t (&stick_max)[2], const char *name)
+{
+  bool updated = false;
+
+  if (stick[CWIID_X] < stick_min[CWIID_X])
+  {
+    stick_min[CWIID_X] = stick[CWIID_X];
+    updated = true;
+  }
+
+  if (stick[CWIID_Y] < stick_min[CWIID_Y])
+  {
+    stick_min[CWIID_Y] = stick[CWIID_Y];
+    updated = true;
+  }
+
+  if (stick[CWIID_X] > stick_max[CWIID_X])
+  {
+    stick_max[CWIID_X] = stick[CWIID_X];
+    updated = true;
+  }
+
+  if (stick[CWIID_Y] > stick_max[CWIID_Y])
+  {
+    stick_max[CWIID_Y] = stick[CWIID_Y];
+    updated = true;
+  }
+
+  if (updated)
+  {
+    ROS_DEBUG("%s Joystick:: Min x:%3d, y:%3d  Max x:%3d, y:%3d", name,
+        stick_min[CWIID_X], stick_min[CWIID_Y], stick_max[CWIID_X], stick_max[CWIID_Y]);
+  }
+}
+
+void WiimoteNode::calculateJoystickAxisXY(uint8_t stick_current[2], uint8_t stick_min[2],
+    uint8_t stick_max[2], uint8_t stick_center[2], double (&stick)[2])
+{
+  double deadzone[2];
+  int deadzoneMargin = 4;
+
+  // Scale the Wiimote Joystick integer values (0-31, 63, or 255)
+  // to a double value between 0.0 and 1.0.
+
+  // The width of the center deadzone needs to scale
+  // with the resolution of the joystick in use.
+  // Nunchuk range is 0-255; defaults to 4
+  // Classic Left range is 0-63; set to 2
+  // Classic Right range is 0-31; set to 1
+  // Original Python implementation was always 0.05 for all
+
+  // Optimize for Nunchuk case; most common
+  if (stick_max[CWIID_X] < 128)
+  {
+    if (stick_max[CWIID_X] < 32)
+    {
+      deadzoneMargin = 1;
+    }
+    else if (stick_max[CWIID_X] < 64)
+    {
+      deadzoneMargin = 2;
+    }
+    else
+    {
+      // No known wiimote joystick uses this range
+      deadzoneMargin = 3;
+    }
+  }
+
+  if (stick_current[CWIID_X] > stick_center[CWIID_X])
+  {
+    stick[CWIID_X] = -(stick_current[CWIID_X] - stick_center[CWIID_X]) /
+      ((stick_max[CWIID_X] - stick_center[CWIID_X]) * 1.0);
+    deadzone[CWIID_X] = deadzoneMargin /
+      ((stick_max[CWIID_X] - stick_center[CWIID_X]) * 1.0);
+  }
+  else
+  {
+    stick[CWIID_X] = -(stick_current[CWIID_X] - stick_center[CWIID_X]) /
+      ((stick_center[CWIID_X] - stick_min[CWIID_X]) * 1.0);
+    deadzone[CWIID_X] = deadzoneMargin /
+      ((stick_center[CWIID_X] - stick_min[CWIID_X]) * 1.0);
+  }
+  if (stick_current[CWIID_Y] > stick_center[CWIID_Y])
+  {
+    stick[CWIID_Y] = (stick_current[CWIID_Y] - stick_center[CWIID_Y]) /
+      ((stick_max[CWIID_Y] - stick_center[CWIID_Y]) * 1.0);
+    deadzone[CWIID_Y] = deadzoneMargin /
+      ((stick_max[CWIID_Y] - stick_center[CWIID_Y]) * 1.0);
+  }
+  else
+  {
+    stick[CWIID_Y] = (stick_current[CWIID_Y] - stick_center[CWIID_Y]) /
+      ((stick_center[CWIID_Y] - stick_min[CWIID_Y]) * 1.0);
+    deadzone[CWIID_Y] = deadzoneMargin /
+      ((stick_center[CWIID_Y] - stick_min[CWIID_Y]) * 1.0);
+  }
+
+  // Create a deadzone in the center
+  if (fabs(stick[CWIID_X]) <= deadzone[CWIID_X])
+  {
+    stick[CWIID_X] = 0.0;
+  }
+  if (fabs(stick[CWIID_Y]) <= deadzone[CWIID_Y])
+  {
+    stick[CWIID_Y] = 0.0;
+  }
+}
+
+void WiimoteNode::publishJoy()
+{
+  sensor_msgs::Joy joy_data;
+
+  joy_data.header.stamp.sec = state_secs_;
+  joy_data.header.stamp.nsec = state_nsecs_;
+
+  joy_data.axes.push_back(zeroedByCal(wiimote_state_.acc[CWIID_X],
+        wiimote_cal_.zero[CWIID_X], wiimote_cal_.one[CWIID_X]) * EARTH_GRAVITY_);
+  joy_data.axes.push_back(zeroedByCal(wiimote_state_.acc[CWIID_Y],
+        wiimote_cal_.zero[CWIID_Y], wiimote_cal_.one[CWIID_Y]) * EARTH_GRAVITY_);
+  joy_data.axes.push_back(zeroedByCal(wiimote_state_.acc[CWIID_Z],
+        wiimote_cal_.zero[CWIID_Z], wiimote_cal_.one[CWIID_Z]) * EARTH_GRAVITY_);
+
+  // NOTE: Order is different for /wiimote/state
+  // Keep consistency with existing Python Node
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_1) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_2) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_A) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_B) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_PLUS) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_MINUS) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_LEFT) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_RIGHT) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_UP) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_DOWN) > 0);
+  joy_data.buttons.push_back((wiimote_state_.buttons & CWIID_BTN_HOME) > 0);
+
+  joy_pub_.publish(joy_data);
+}
+
+void WiimoteNode::publishImuData()
+{
+  // The Wiimote provides the Acceleration and optionally Gyro
+  // if MotionPlus is available, but not orientation information.
+
+  sensor_msgs::Imu imu_data_data;
+
+  imu_data_data.header.stamp.sec = state_secs_;
+  imu_data_data.header.stamp.nsec = state_nsecs_;
+
+  // Publish that Orientation data is invalid
+  // [ -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 ]
+  imu_data_data.orientation_covariance[0] = -1.0;
+
+  // Acceleration
+  imu_data_data.linear_acceleration.x = zeroedByCal(wiimote_state_.acc[CWIID_X],
+      wiimote_cal_.zero[CWIID_X], wiimote_cal_.one[CWIID_X]) * EARTH_GRAVITY_;
+  imu_data_data.linear_acceleration.y = zeroedByCal(wiimote_state_.acc[CWIID_Y],
+      wiimote_cal_.zero[CWIID_Y], wiimote_cal_.one[CWIID_Y]) * EARTH_GRAVITY_;
+  imu_data_data.linear_acceleration.z = zeroedByCal(wiimote_state_.acc[CWIID_Z],
+      wiimote_cal_.zero[CWIID_Z], wiimote_cal_.one[CWIID_Z]) * EARTH_GRAVITY_;
+
+  imu_data_data.linear_acceleration_covariance = linear_acceleration_covariance_;
+
+  // MotionPlus Gyro
+  if (isPresentMotionplus())
+  {
+    imu_data_data.angular_velocity.x = (wiimote_state_.ext.motionplus.angle_rate[CWIID_PHI] -
+        angular_velocity_stat_.getMeanRaw()[CWIID_PHI]) * GYRO_SCALE_FACTOR_;
+    imu_data_data.angular_velocity.y = (wiimote_state_.ext.motionplus.angle_rate[CWIID_THETA] -
+        angular_velocity_stat_.getMeanRaw()[CWIID_THETA]) * GYRO_SCALE_FACTOR_;
+    imu_data_data.angular_velocity.z = (wiimote_state_.ext.motionplus.angle_rate[CWIID_PSI] -
+        angular_velocity_stat_.getMeanRaw()[CWIID_PSI]) * GYRO_SCALE_FACTOR_;
+  }
+
+  imu_data_data.angular_velocity_covariance = angular_velocity_covariance_;
+
+  imu_data_pub_.publish(imu_data_data);
+}
+
+void WiimoteNode::publishWiimoteState()
+{
+  wiimote::State wiimote_state_data;
+
+  wiimote_state_data.header.stamp.sec = state_secs_;
+  wiimote_state_data.header.stamp.nsec = state_nsecs_;
+
+  // Wiimote data
+  wiimote_state_data.linear_acceleration_zeroed.x = zeroedByCal(wiimote_state_.acc[CWIID_X],
+      wiimote_cal_.zero[CWIID_X], wiimote_cal_.one[CWIID_X]) * EARTH_GRAVITY_;
+  wiimote_state_data.linear_acceleration_zeroed.y = zeroedByCal(wiimote_state_.acc[CWIID_Y],
+      wiimote_cal_.zero[CWIID_Y], wiimote_cal_.one[CWIID_Y]) * EARTH_GRAVITY_;
+  wiimote_state_data.linear_acceleration_zeroed.z = zeroedByCal(wiimote_state_.acc[CWIID_Z],
+      wiimote_cal_.zero[CWIID_Z], wiimote_cal_.one[CWIID_Z]) * EARTH_GRAVITY_;
+
+  wiimote_state_data.linear_acceleration_raw.x = wiimote_state_.acc[CWIID_X];
+  wiimote_state_data.linear_acceleration_raw.y = wiimote_state_.acc[CWIID_Y];
+  wiimote_state_data.linear_acceleration_raw.z = wiimote_state_.acc[CWIID_Z];
+
+  wiimote_state_data.linear_acceleration_covariance = linear_acceleration_covariance_;
+
+  // MotionPlus Gyro
+  wiimote_state_data.angular_velocity_covariance = angular_velocity_covariance_;
+
+  if (isPresentMotionplus())
+  {
+    wiimote_state_data.angular_velocity_zeroed.x = (wiimote_state_.ext.motionplus.angle_rate[CWIID_PHI] -
+        angular_velocity_stat_.getMeanRaw()[CWIID_PHI]) * GYRO_SCALE_FACTOR_;
+    wiimote_state_data.angular_velocity_zeroed.y = (wiimote_state_.ext.motionplus.angle_rate[CWIID_THETA] -
+        angular_velocity_stat_.getMeanRaw()[CWIID_THETA]) * GYRO_SCALE_FACTOR_;
+    wiimote_state_data.angular_velocity_zeroed.z = (wiimote_state_.ext.motionplus.angle_rate[CWIID_PSI] -
+        angular_velocity_stat_.getMeanRaw()[CWIID_PSI]) * GYRO_SCALE_FACTOR_;
+
+    wiimote_state_data.angular_velocity_raw.x = wiimote_state_.ext.motionplus.angle_rate[CWIID_PHI];
+    wiimote_state_data.angular_velocity_raw.y = wiimote_state_.ext.motionplus.angle_rate[CWIID_THETA];
+    wiimote_state_data.angular_velocity_raw.z = wiimote_state_.ext.motionplus.angle_rate[CWIID_PSI];
+  }
+
+  // NOTE: Order is different for /joy
+  // Keep consistency with existing Python Node
+  wiimote_state_data.buttons.elems[ 0] = ((wiimote_state_.buttons & CWIID_BTN_1) > 0);
+  wiimote_state_data.buttons.elems[ 1] = ((wiimote_state_.buttons & CWIID_BTN_2) > 0);
+  wiimote_state_data.buttons.elems[ 2] = ((wiimote_state_.buttons & CWIID_BTN_PLUS) > 0);
+  wiimote_state_data.buttons.elems[ 3] = ((wiimote_state_.buttons & CWIID_BTN_MINUS) > 0);
+  wiimote_state_data.buttons.elems[ 4] = ((wiimote_state_.buttons & CWIID_BTN_A) > 0);
+  wiimote_state_data.buttons.elems[ 5] = ((wiimote_state_.buttons & CWIID_BTN_B) > 0);
+  wiimote_state_data.buttons.elems[ 6] = ((wiimote_state_.buttons & CWIID_BTN_UP) > 0);
+  wiimote_state_data.buttons.elems[ 7] = ((wiimote_state_.buttons & CWIID_BTN_DOWN) > 0);
+  wiimote_state_data.buttons.elems[ 8] = ((wiimote_state_.buttons & CWIID_BTN_LEFT) > 0);
+  wiimote_state_data.buttons.elems[ 9] = ((wiimote_state_.buttons & CWIID_BTN_RIGHT) > 0);
+  wiimote_state_data.buttons.elems[10] = ((wiimote_state_.buttons & CWIID_BTN_HOME) > 0);
+
+  // Nunchuk data
+  if (isPresentNunchuk())
+  {
+    if (publishWiimoteNunchukCommon())
+    {
+      // Joy stick
+      double stick[2];
+
+      calculateJoystickAxisXY(wiimote_state_.ext.nunchuk.stick, nunchuk_stick_min_,
+          nunchuk_stick_max_, nunchuk_stick_center_, stick);
+
+      wiimote_state_data.nunchuk_joystick_raw[CWIID_X] = wiimote_state_.ext.nunchuk.stick[CWIID_X];
+      wiimote_state_data.nunchuk_joystick_raw[CWIID_Y] = wiimote_state_.ext.nunchuk.stick[CWIID_Y];
+
+      wiimote_state_data.nunchuk_joystick_zeroed[CWIID_X] = stick[CWIID_X];
+      wiimote_state_data.nunchuk_joystick_zeroed[CWIID_Y] = stick[CWIID_Y];
+
+      wiimote_state_data.nunchuk_acceleration_raw.x = wiimote_state_.ext.nunchuk.acc[CWIID_X];
+      wiimote_state_data.nunchuk_acceleration_raw.y = wiimote_state_.ext.nunchuk.acc[CWIID_Y];
+      wiimote_state_data.nunchuk_acceleration_raw.z = wiimote_state_.ext.nunchuk.acc[CWIID_Z];
+
+      wiimote_state_data.nunchuk_acceleration_zeroed.x =
+        zeroedByCal(wiimote_state_.ext.nunchuk.acc[CWIID_X],
+            nunchuk_cal_.zero[CWIID_X], nunchuk_cal_.one[CWIID_X]) * EARTH_GRAVITY_;
+      wiimote_state_data.nunchuk_acceleration_zeroed.y =
+        zeroedByCal(wiimote_state_.ext.nunchuk.acc[CWIID_Y],
+            nunchuk_cal_.zero[CWIID_Y], nunchuk_cal_.one[CWIID_Y]) * EARTH_GRAVITY_;
+      wiimote_state_data.nunchuk_acceleration_zeroed.z =
+        zeroedByCal(wiimote_state_.ext.nunchuk.acc[CWIID_Z],
+            nunchuk_cal_.zero[CWIID_Z], nunchuk_cal_.one[CWIID_Z]) * EARTH_GRAVITY_;
+
+      // Keep consistency with existing Python Node
+      wiimote_state_data.nunchuk_buttons[0] =
+        ((wiimote_state_.ext.nunchuk.buttons & CWIID_NUNCHUK_BTN_Z) > 0);
+      wiimote_state_data.nunchuk_buttons[1] =
+        ((wiimote_state_.ext.nunchuk.buttons & CWIID_NUNCHUK_BTN_C) > 0);
+    }
+  }
+
+  // IR Tracking Data
+  for (int ir_idx = 0; ir_idx < CWIID_IR_SRC_COUNT; ir_idx++)
+  {
+    wiimote::IrSourceInfo irSourceInfo;
+
+    if (wiimote_state_.ir_src[ir_idx].valid)
+    {
+      irSourceInfo.x = wiimote_state_.ir_src[ir_idx].pos[CWIID_X];
+      irSourceInfo.y = wiimote_state_.ir_src[ir_idx].pos[CWIID_Y];
+
+      irSourceInfo.ir_size = wiimote_state_.ir_src[ir_idx].size;
+
+      if (irSourceInfo.ir_size < 1)
+      {
+        irSourceInfo.ir_size = wiimote::State::INVALID;
+      }
+    }
+    else
+    {
+      irSourceInfo.x = wiimote::State::INVALID_FLOAT;
+      irSourceInfo.y = wiimote::State::INVALID_FLOAT;
+
+      irSourceInfo.ir_size = wiimote::State::INVALID;
+    }
+
+    wiimote_state_data.ir_tracking.push_back(irSourceInfo);
+  }
+
+  // LEDs / Rumble
+  for (uint8_t i = 0; i < 4; i++)
+  {
+    wiimote_state_data.LEDs[i] = wiimote_state_.led & (0x1 << i);
+  }
+  wiimote_state_data.rumble = wiimote_state_.rumble & 0x1;
+
+  // Battery
+  wiimote_state_data.raw_battery = wiimote_state_.battery;
+  wiimote_state_data.percent_battery = wiimote_state_.battery * 100.0 / CWIID_BATTERY_MAX;
+
+  // Zeroing time (aka Calibration time)
+  wiimote_state_data.zeroing_time = calibration_time_;
+
+  // Wiimote state errors
+  // No usage found in original Python code which every set this variable
+  // TODO(mdhorn): Use this to report error
+  // Is this a count? or a bunch of status that are ORed together?
+  wiimote_state_data.errors = wiimote_errors;
+
+  wiimote_state_pub_.publish(wiimote_state_data);
+}
+
+bool WiimoteNode::publishWiimoteNunchukCommon()
+{
+  // Testing different Nunchuks show that they have different
+  // centers and different range of motion.
+  //
+  // Best Approximation:
+  // Grabbing the first set of x, y with the assumption of
+  // the joystick is centered.
+  // We know the joystick can only report between 0 and 255
+  // for each axis; so assume a 20% guard band to set the
+  // initial minimums and maximums. As the joystick is used,
+  // updated the min/max values based on observed data.
+  // This will have the effect of a less throw of the joystick
+  // throttle during first movement to the max/min position.
+  //
+  // TODO(mdhorn): Could be improved by a true user interaction calibration
+  // to find the center of the joystick, the max and min for each x and y.
+  // But the effort in coding and extra burden on the one the user
+  // may not be warranted.
+
+  bool result = true;
+
+  if (isPresentNunchuk())
+  {
+    if (!nunchuk_stick_calibrated_)
+    {
+      nunchuk_stick_calibrated_ = calibrateJoystick(
+          wiimote_state_.ext.nunchuk.stick, nunchuk_stick_center_, "Nunchuk");
+
+      // Don't publish if we haven't found the center position
+      if (!nunchuk_stick_calibrated_)
+      {
+        result = false;
+      }
+    }
+
+    updateJoystickMinMax(wiimote_state_.ext.nunchuk.stick, nunchuk_stick_min_,
+        nunchuk_stick_max_, "Nunchuk");
+  }
+  else
+  {
+    ROS_WARN("State type is not Nunchuk!");
+    result = false;
+  }
+
+  return result;
+}
+
+void WiimoteNode::publishWiimoteNunchuk()
+{
+  sensor_msgs::Joy wiimote_nunchuk_data;
+
+  if (publishWiimoteNunchukCommon())
+  {
+    wiimote_nunchuk_data.header.stamp.sec = state_secs_;
+    wiimote_nunchuk_data.header.stamp.nsec = state_nsecs_;
+
+    // Joy stick
+    double stick[2];
+
+    calculateJoystickAxisXY(wiimote_state_.ext.nunchuk.stick, nunchuk_stick_min_,
+        nunchuk_stick_max_, nunchuk_stick_center_, stick);
+
+    wiimote_nunchuk_data.axes.push_back(stick[CWIID_X]);  // x
+    wiimote_nunchuk_data.axes.push_back(stick[CWIID_Y]);  // y
+
+    wiimote_nunchuk_data.axes.push_back(zeroedByCal(wiimote_state_.ext.nunchuk.acc[CWIID_X],
+          nunchuk_cal_.zero[CWIID_X], nunchuk_cal_.one[CWIID_X]) * EARTH_GRAVITY_);
+    wiimote_nunchuk_data.axes.push_back(zeroedByCal(wiimote_state_.ext.nunchuk.acc[CWIID_Y],
+          nunchuk_cal_.zero[CWIID_Y], nunchuk_cal_.one[CWIID_Y]) * EARTH_GRAVITY_);
+    wiimote_nunchuk_data.axes.push_back(zeroedByCal(wiimote_state_.ext.nunchuk.acc[CWIID_Z],
+          nunchuk_cal_.zero[CWIID_Z], nunchuk_cal_.one[CWIID_Z]) * EARTH_GRAVITY_);
+
+
+    // NOTE: Order is different for /wiimote/state
+    // Keep consistency with existing Python Node
+    wiimote_nunchuk_data.buttons.push_back((wiimote_state_.ext.nunchuk.buttons & CWIID_NUNCHUK_BTN_Z) > 0);
+    wiimote_nunchuk_data.buttons.push_back((wiimote_state_.ext.nunchuk.buttons & CWIID_NUNCHUK_BTN_C) > 0);
+
+    wiimote_nunchuk_pub_.publish(wiimote_nunchuk_data);
+  }
+}
+
+void WiimoteNode::publishWiimoteClassic()
+{
+  // Using the same "Best Approximation" methods from
+  // WiimoteNode::publishWiimoteNunchuk()
+
+  sensor_msgs::Joy wiimote_classic_data;
+
+  if (isPresentClassic())
+  {
+    ROS_WARN("State type is not Classic!");
+    return;
+  }
+
+  if (!classic_stick_left_calibrated_)
+  {
+    classic_stick_left_calibrated_ = calibrateJoystick(
+        wiimote_state_.ext.classic.l_stick, classic_stick_left_center_, "Classic Left");
+  }
+
+  if (!classic_stick_right_calibrated_)
+  {
+    classic_stick_right_calibrated_ = calibrateJoystick(
+        wiimote_state_.ext.classic.r_stick, classic_stick_right_center_, "Classic Right");
+  }
+
+  if ((!classic_stick_left_calibrated_) ||
+      (!classic_stick_right_calibrated_))
+  {
+    // Don't publish if we haven't found the center positions
+    return;
+  }
+
+  updateJoystickMinMax(wiimote_state_.ext.classic.l_stick, classic_stick_left_min_,
+      classic_stick_left_max_, "Classic Left");
+  updateJoystickMinMax(wiimote_state_.ext.classic.r_stick, classic_stick_right_min_,
+      classic_stick_right_max_, "Classic Right");
+
+  wiimote_classic_data.header.stamp.sec = state_secs_;
+  wiimote_classic_data.header.stamp.nsec = state_nsecs_;
+
+  // Joy stick
+  double stick_left[2];
+  double stick_right[2];
+
+  calculateJoystickAxisXY(wiimote_state_.ext.classic.l_stick, classic_stick_left_min_,
+      classic_stick_left_max_, classic_stick_left_center_, stick_left);
+  calculateJoystickAxisXY(wiimote_state_.ext.classic.r_stick, classic_stick_right_min_,
+      classic_stick_right_max_, classic_stick_right_center_, stick_right);
+
+  wiimote_classic_data.axes.push_back(stick_left[CWIID_X]);   // Left x
+  wiimote_classic_data.axes.push_back(stick_left[CWIID_Y]);   // Left y
+  wiimote_classic_data.axes.push_back(stick_right[CWIID_X]);  // Right x
+  wiimote_classic_data.axes.push_back(stick_right[CWIID_Y]);  // Right y
+
+  // NOTE: Order is different for /wiimote/state
+  // Keep consistency with existing Python Node
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_X) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_Y) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_A) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_B) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_PLUS) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_MINUS) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_LEFT) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_RIGHT) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_UP) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_DOWN) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_HOME) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_L) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_R) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_ZL) > 0);
+  wiimote_classic_data.buttons.push_back((wiimote_state_.ext.classic.buttons & CWIID_CLASSIC_BTN_ZR) > 0);
+
+  wiimote_classic_pub_.publish(wiimote_classic_data);
+}
+
+// const sensor_msgs::JoyFeedbackArray::ConstPtr& feedback is unused
+void WiimoteNode::joySetFeedbackCallback(const sensor_msgs::JoyFeedbackArray::ConstPtr& feedback)
+{
+  bool led_found = false;
+  bool rumble_found = false;
+
+  for (std::vector<sensor_msgs::JoyFeedback>::const_iterator it = feedback->array.begin();
+      it != feedback->array.end(); ++it)
+  {
+    if ((*it).type == sensor_msgs::JoyFeedback::TYPE_LED)
+    {
+      led_found = true;
+
+      if ((*it).intensity >= 0.5)
+      {
+        setLEDBit((*it).id, true);
+      }
+      else
+      {
+        setLEDBit((*it).id, false);
+      }
+    }
+    else if ((*it).type == sensor_msgs::JoyFeedback::TYPE_RUMBLE)
+    {
+      if ((*it).id > 0)
+      {
+        ROS_WARN("RUMBLE ID %d out of bounds; ignoring!", (*it).id);
+      }
+      else
+      {
+        rumble_found = true;
+
+        if ((*it).intensity >= 0.5)
+        {
+          setRumbleBit(true);
+        }
+        else
+        {
+          setRumbleBit(false);
+        }
+      }
+    }
+    else
+    {
+      ROS_WARN("Unknown JoyFeedback command; ignored");
+    }
+  }
+
+  if (led_found)
+  {
+    setLedState(led_state_);
+  }
+
+  if (rumble_found)
+  {
+    setRumbleState(rumble_);
+  }
+}
+
+bool WiimoteNode::serviceImuCalibrateCallback(std_srvs::Empty::Request&, std_srvs::Empty::Response&)
+{
+  // Publish the new calibration state
+  checkFactoryCalibrationData();
+
+  return true;
+}
+
+WiimoteNode *g_wiimote_node;
+
+// int sig The signal number is unused
+void mySigHandler(int sig)
+{
+  // Do some custom action.
+  // For example, publish a stop message to some other nodes.
+
+  // Clear the lights and rumble
+  if (nullptr != g_wiimote_node)
+  {
+    g_wiimote_node->setRumbleState(0);
+    g_wiimote_node->setLedState(0);
+  }
+
+  // All the default sigint handler does is call shutdown()
+  ros::shutdown();
+
+  exit(0);
+}
+
+int main(int argc, char *argv[])
+{
+  ros::init(argc, argv, "wiimote_controller");
+
+  g_wiimote_node = new WiimoteNode();
+
+  // Do we have a bluetooth address passed in?
+  if (argc > 1)
+  {
+    g_wiimote_node->setBluetoothAddr(argv[1]);
+  }
+
+  ROS_INFO("* * * Pairing");
+  ROS_INFO("Allow all joy sticks to remain at center position until calibrated.");
+  if (g_wiimote_node->pairWiimote())
+  {
+    ROS_INFO("Wiimote is Paired");
+
+    signal(SIGINT, mySigHandler);
+    signal(SIGTERM, mySigHandler);
+  }
+  else
+  {
+    ROS_ERROR("* * * Wiimote pairing failed.");
+    ros::shutdown();
+  }
+
+  ros::Rate loop_rate(10);  // 10Hz
+
+  while (ros::ok())
+  {
+    g_wiimote_node->publish();
+
+    ros::spinOnce();
+
+    loop_rate.sleep();
+  }
+
+  if (g_wiimote_node->unpairWiimote())
+  {
+    ROS_ERROR("Error on wiimote disconnect");
+    return -1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Rewrite of the Wiimote node in C++ using the existing Python node
as the requirements. The C++ implementation was designed with focus
on reduced resource consumption.

Using C++ cut the memory consumption by 50-60%, and the reduced the
number of cpu-clock cycles used 20x-30x depending upon the use case.

Differences from Python implementation:
- Both "/wiimote/nunchuk" and "/wiimote/classic" topics are only
  published if the Nunchuk or Classic Controller are connected to
  the wiimote respectively.
- Wiimote data is only polled from the controller if the data is
  required to publish for a topic which has at least one subscriber.

See Issue: 
https://github.com/ros-drivers/joystick_drivers/issues/85
