### PR TITLE
Update dependencies to remove warnings

### DIFF
--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -4,9 +4,8 @@ project(joy)
 
 # Load catkin and all dependencies required for this package
 set(CATKIN_DEPS roscpp diagnostic_updater sensor_msgs)
-set(ROSDEP_DEPS joystick)
 find_package(catkin REQUIRED ${CATKIN_DEPS})
-catkin_package(DEPENDS ${CATKIN_DEPS} ${ROSDEP_DEPS})
+catkin_package(DEPENDS ${CATKIN_DEPS})
 
 # Look for <linux/joystick.h>
 include(CheckIncludeFiles)

--- a/ps3joy/CMakeLists.txt
+++ b/ps3joy/CMakeLists.txt
@@ -2,11 +2,19 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ps3joy)
 
+find_package(PkgConfig REQUIRED)
+pkg_search_module(LIBUSB REQUIRED libusb)
+if(LIBUSB_FOUND)
+  include_directories(SYSTEM ${LIBUSB_INCLUDE_DIRS})
+  link_directories(${LIBUSB_LIBRARY_DIRS})
+else()
+  message( FATAL_ERROR "Failed to find libusb" )
+endif(LIBUSB_FOUND)
+
 # Load catkin and all dependencies required for this package
 set(CATKIN_DEPS diagnostic_msgs sensor_msgs rospy rosgraph)
-set(ROSDEP_DEPS libusb-dev joystick bluez python-bluez)
-find_package(catkin REQUIRED ${CATKIN_DEPS})
-catkin_package(DEPENDS ${CATKIN_DEPS} ${ROSDEP_DEPS})
+find_package(catkin REQUIRED COMPONENTS ${CATKIN_DEPS})
+catkin_package(CATKIN_DEPENDS ${CATKIN_DEPS})
 
 include_directories(${catkin_INCLUDE_DIRS})
 add_executable(sixpair src/sixpair.c)

--- a/spacenav_node/CMakeLists.txt
+++ b/spacenav_node/CMakeLists.txt
@@ -4,9 +4,8 @@ project(spacenav_node)
 
 # Load catkin and all dependencies required for this package
 set(CATKIN_DEPS roscpp geometry_msgs sensor_msgs)
-set(ROSDEP_DEPS libspnav-dev spacenavd)
 find_package(catkin REQUIRED ${CATKIN_DEPS})
-catkin_package(DEPENDS ${CATKIN_DEPS} ${ROSDEP_DEPS})
+catkin_package(DEPENDS ${CATKIN_DEPS})
 
 include_directories(${catkin_INCLUDE_DIRS})
 add_executable(spacenav_node src/spacenav_node.cpp)

--- a/wiimote/CMakeLists.txt
+++ b/wiimote/CMakeLists.txt
@@ -16,7 +16,6 @@ set(CMAKE_SHARED_LINKER_FLAGS "-z noexecstack -z relro -z now ${CMAKE_SHARED_LIN
 
 # Load catkin and all dependencies required for this package
 set(CATKIN_DEPS geometry_msgs sensor_msgs std_msgs std_srvs rospy roscpp roslib genmsg)
-set(ROSDEP_DEPS python-numpy python-cwiid)
 find_package(catkin REQUIRED ${CATKIN_DEPS} roslint)
 
 catkin_python_setup()
@@ -47,8 +46,7 @@ roslint_add_test()
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS ${CATKIN_DEPS}
-  bluetooth cwiid
+  CATKIN_DEPENDS ${CATKIN_DEPS}
 )
 
 ## Specify additional locations of header files


### PR DESCRIPTION
Recent updates in Kinetic cause build warning. 
Updated dependencies to work for both Indigo and Kinetic without build warnings.