### PR TITLE
Add CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,16 @@ env:
     - ROS_DISTRO="jade"   PRERELEASE=true
     - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - ROS_DISTRO="kinetic"  PRERELEASE=true
+    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="lunar"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="lunar"  PRERELEASE=true
 matrix:
   allow_failures:
     - env: ROS_DISTRO="indigo" PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
     - env: ROS_DISTRO="jade"   PRERELEASE=true
     - env: ROS_DISTRO="kinetic"  PRERELEASE=true
+    - env: ROS_DISTRO="lunar"  PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# This config file for Travis CI utilizes ros-industrial/industrial_ci package.
+# For more info for the package, see https://github.com/ros-industrial/industrial_ci/blob/master/README.rst
+sudo: required 
+dist: trusty 
+services:
+  - docker
+language: generic 
+compiler:
+  - gcc
+notifications:
+  email:
+    recipients:
+      - gm130s@gmail.com
+env:
+  matrix:
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="indigo" PRERELEASE=true
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="jade"   PRERELEASE=true
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic"  PRERELEASE=true
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO="indigo" PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
+    - env: ROS_DISTRO="jade"   PRERELEASE=true
+    - env: ROS_DISTRO="kinetic"  PRERELEASE=true
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh
+#  - source ./travis.sh  # Enable this when you have a package-local script 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ env:
 matrix:
   allow_failures:
     - env: ROS_DISTRO="indigo" PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
+    - env: ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="jade"   PRERELEASE=true
     - env: ROS_DISTRO="kinetic"  PRERELEASE=true
     - env: ROS_DISTRO="lunar"  PRERELEASE=true


### PR DESCRIPTION
[industrial_ci](https://github.com/ros-industrial/industrial_ci) is a set of scripts for continuous integration on ROS. This simple config enables CI to run on `Travis CI` for this repo. Contrary to its name it works for non-industrial ROS packages as well.

If this looks good, can any admin enable Travis for this repo at https://travis-ci.org/profile/ros-drivers?