### PR TITLE
Fixed #91

### DIFF
--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -255,7 +255,7 @@ public:
             else
                 val = 0;
             joy_msg.axes[event.number] = val * scale;
-            // Will wait a bit before sending to try to combine events. 				
+            // Will wait a bit before sending to try to combine events.
             publish_soon = true;
             break;
           default:

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -187,6 +187,7 @@ public:
       tv.tv_sec = 1;
       tv.tv_usec = 0;
       sensor_msgs::Joy joy_msg; // Here because we want to reset it on device close.
+      double val = 0.0f;
       while (nh_.ok()) 
       {
         ros::spinOnce();
@@ -237,6 +238,7 @@ public:
             break;
           case JS_EVENT_AXIS:
           case JS_EVENT_AXIS | JS_EVENT_INIT:
+            val = event.value;
             if(event.number >= joy_msg.axes.size())
             {
               int old_size = joy_msg.axes.size();
@@ -244,18 +246,15 @@ public:
               for(unsigned int i=old_size;i<joy_msg.axes.size();i++)
                 joy_msg.axes[i] = 0.0;
             }
-            if (!(event.type & JS_EVENT_INIT)) // Init event.value is wrong.
-            {
-              double val = event.value;
-              // Allows deadzone to be "smooth"
-              if (val > unscaled_deadzone)
+            
+            // Allows deadzone to be "smooth"
+            if (val > unscaled_deadzone)
                 val -= unscaled_deadzone;
-              else if (val < -unscaled_deadzone)
+            else if (val < -unscaled_deadzone)
                 val += unscaled_deadzone;
-              else
+            else
                 val = 0;
-              joy_msg.axes[event.number] = val * scale;
-            }
+            joy_msg.axes[event.number] = val * scale;
             // Will wait a bit before sending to try to combine events. 				
             publish_soon = true;
             break;


### PR DESCRIPTION
The joystick values did not got published until their values changed because the JS_EVENT_INIT type events were ignored, and 0.0 is published until their values changed. 

In many cases this is an unexpected behaviour (for e.g. see #91 )

If you have any objection or had specific reason why you implemented such a way please let me know, and I will add a parameter to be able to change this behaviour. 

Thank you in advance!