### PR TITLE
Add timestamp to all joy messages

### DIFF
--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -291,6 +291,7 @@ public:
             break; // Joystick is probably closed. Definitely occurs.
 
           //ROS_INFO("Read data...");
+          joy_msg.header.stamp = ros::Time().now();
           event_count_++;
           switch(event.type)
           {
@@ -368,6 +369,7 @@ public:
         }
         else if (tv_set) // Assume that the timer has expired.
         {
+          joy_msg.header.stamp = ros::Time().now();
           publish_now = true;
         }
 

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -291,7 +291,6 @@ public:
             break; // Joystick is probably closed. Definitely occurs.
 
           //ROS_INFO("Read data...");
-          joy_msg.header.stamp = ros::Time().now();
           event_count_++;
           switch(event.type)
           {
@@ -369,7 +368,6 @@ public:
         }
         else if (tv_set) // Assume that the timer has expired.
         {
-          joy_msg.header.stamp = ros::Time().now();
           publish_now = true;
         }
 
@@ -400,6 +398,7 @@ public:
             }
             pub_.publish(sticky_buttons_joy_msg);
           } else {
+            joy_msg.header.stamp = ros::Time().now();
             pub_.publish(joy_msg);
           }
 


### PR DESCRIPTION
Prior to this commit there were some joy messages getting published that were not getting timestamps. This commit adds functionality so that all messages are published with timestamps.