### PR TITLE
Check if wiimote is still connected.

### DIFF
--- a/wiimote/include/wiimote/wiimote_controller.h
+++ b/wiimote/include/wiimote/wiimote_controller.h
@@ -66,6 +66,8 @@ public:
   int unpairWiimote();
 
   void publish();
+  void checkConnection();
+  void timerCallback(const ros::TimerEvent&);
 
   void setLedState(uint8_t led_state);
   void setRumbleState(uint8_t rumble);


### PR DESCRIPTION
We need to detect when the wiimote disconnects.

This solution checks the connection to the wiimote by writing some registers. If the write fails we expect the wiimote is disconnected.

There's a paramter for configuration. The default does not change the current behavior.