### PR TITLE
return instead of shutdown

### DIFF
--- a/wiimote/src/wiimote_controller.cpp
+++ b/wiimote/src/wiimote_controller.cpp
@@ -1630,7 +1630,7 @@ int main(int argc, char *argv[])
   else
   {
     ROS_ERROR("* * * Wiimote pairing failed.");
-    ros::shutdown();
+    return -2;
   }
 
   ros::NodeHandle nh;


### PR DESCRIPTION
Justification for +return:
- Prevents the node from crashing
- Adds a usable exit code (maybe choose another value?)
- IMO that's the original intension

Justification for -shutdown:
- Not required, there's no Spinner running