### PR TITLE
ROS2 joy node basics working

### DIFF
--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(joy)
 
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -10,10 +15,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
+#find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
 include_directories(include)
@@ -26,32 +32,22 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   check_include_files(linux/joystick.h HAVE_LINUX_JOYSTICK_H)
 
   if(HAVE_LINUX_JOYSTICK_H)
-    add_library(
-      ${PROJECT_NAME}_node SHARED
-      src/joy_node.cpp
-    )
-    target_compile_definitions(
+    add_executable(
       ${PROJECT_NAME}_node
-      PRIVATE "COMPOSITION_BUILDING_DLL"
+      src/joy_node.cpp
+      src/joystick_data.cpp
+      src/linux_force_feedback.cpp
+      src/linux_helper.cpp
+      src/linux_joystick.cpp
     )
-    ament_target_dependencies(joy_node
+    ament_target_dependencies(${PROJECT_NAME}_node
       "diagnostic_updater"
       "rclcpp"
-      "rclcpp_components"
+      #"rclcpp_components"
       "sensor_msgs"
     )
-    rclcpp_components_register_nodes(
-      ${PROJECT_NAME}_node
-      "joy::JoyNode"
-    )
-    ament_export_interfaces(export_${PROJECT_NAME}_node HAS_LIBRARY_TARGET)
-
-    install(DIRECTORY include/
-      DESTINATION include
-    )
-
+    
     install(TARGETS ${PROJECT_NAME}_node
-      EXPORT export_${PROJECT_NAME}_node
       ARCHIVE DESTINATION lib
       LIBRARY DESTINATION lib
       RUNTIME DESTINATION bin
@@ -60,14 +56,8 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   else()
     message("Warning: no <linux/joystick.h>; won't build joy node")
   endif()
-
-  # install(
-  #   DIRECTORY
-  #     config
-  #     launch
-  #     scripts
-  #   DESTINATION share
-  # )
+else()
+  message("Warning: for now, cannot build joy node for other systems than Linux")
 endif()
 
 if(BUILD_TESTING)

--- a/joy/include/joy/joy_node.hpp
+++ b/joy/include/joy/joy_node.hpp
@@ -1,67 +1,54 @@
-// Copyright 2009, 2020, Willow Garage, Inc., Joshua Whitley
-// All rights reserved.
-//
-// Software License Agreement (BSD License 2.0)
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// * Redistributions of source code must retain the above copyright
-//   notice, this list of conditions and the following disclaimer.
-// * Redistributions in binary form must reproduce the above
-//   copyright notice, this list of conditions and the following
-//   disclaimer in the documentation and/or other materials provided
-//   with the distribution.
-// * Neither the name of {copyright_holder} nor the names of its
-//   contributors may be used to endorse or promote products derived
-//   from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
-#ifndef JOY__JOY_NODE_HPP_
-#define JOY__JOY_NODE_HPP_
+#ifndef ROS2_JOY_JOY_NODE_HPP_INCLUDED
+#define ROS2_JOY_JOY_NODE_HPP_INCLUDED
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <sensor_msgs/msg/joy_feedback_array.hpp>
-
-#include <memory>
 #include <string>
 
-namespace joy
-{
-class JoyNode
-  : public rclcpp::Node
+#include "joystick_data.hpp"
+
+enum class ProcessEventsResult { Continue, Abort, PublishNow, PublishSoon };
+
+class JoyNode : public rclcpp::Node
 {
 public:
-  explicit JoyNode(rclcpp::NodeOptions options);
+  JoyNode(rclcpp::NodeOptions options);
+  virtual ~JoyNode();
+
+  void run();
+
+protected:
+  virtual bool tryOpen(JoystickData &joystick_data) = 0; // Opens the joystick. Returns true on success, false otherwise.
+  virtual void close() = 0;
+  virtual ProcessEventsResult processEvents() = 0;
+
+  virtual void handleSetFeedback(const sensor_msgs::msg::JoyFeedbackArray::SharedPtr msg) = 0;
+
+  void startAutorepeatPublishing(); // starts the autorepeat timer
+  void updateButton(size_t button, int32_t value);
+  void updateAxis(size_t axis, float value);
 
 private:
-  std::string dev_path;
-  std::string dev_ff_path;
-  std::string dev_name;
+  void publish();
+  void handleCoalesceTimerEvent();
+
   double deadzone;
-  double autorepeat_rate;
-  double coalesce_interval;
+  double deadzone_scale;
+  double unscaled_deadzone;
+  double autorepeat_rate; // [Hz], 0 for no repeat
+  double coalesce_interval; // [s], 0 for no coalescence (changes are published immediately)
   bool sticky_buttons;
+
+  // publishing
+  rclcpp::Clock joy_clock;
+  sensor_msgs::msg::Joy joy_msg;
   std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::Joy>> joy_pub;
+  std::shared_ptr<rclcpp::TimerBase> joy_pub_coalesce_timer;
+  std::shared_ptr<rclcpp::TimerBase> joy_pub_autorepeat_timer;
+
+  // subscriber
   std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::JoyFeedbackArray>> feedback_sub;
-
-  void feedback_callback(const sensor_msgs::msg::JoyFeedbackArray::SharedPtr msg);
-  std::string get_dev_path_by_name(const std::string name);
 };
-}  // namespace joy
 
-#endif  // JOY__JOY_NODE_HPP_
+#endif // ROS2_JOY_JOY_NODE_HPP_INCLUDED

--- a/joy/include/joy/joystick_data.hpp
+++ b/joy/include/joy/joystick_data.hpp
@@ -1,0 +1,16 @@
+#ifndef ROS2_JOY_JOYSTICK_DATA_HPP_INCLUDED
+#define ROS2_JOY_JOYSTICK_DATA_HPP_INCLUDED
+
+#include <string>
+
+struct JoystickData
+{
+  std::string device_name;
+  unsigned number_of_axes;
+  unsigned number_of_buttons;
+
+  virtual std::string toBasicInfoString() const;
+  virtual std::string toDetailInfoString() const;
+};
+
+#endif // ROS2_JOY_JOYSTICK_DATA_HPP_INCLUDED

--- a/joy/include/joy/linux_force_feedback.hpp
+++ b/joy/include/joy/linux_force_feedback.hpp
@@ -1,0 +1,31 @@
+#ifndef ROS2_JOY_LINUX_FORCE_FEEDBACK_HPP_INCLUDED
+#define ROS2_JOY_LINUX_FORCE_FEEDBACK_HPP_INCLUDED
+
+#include <rclcpp/logger.hpp>
+#include <sensor_msgs/msg/joy_feedback_array.hpp>
+#include <string>
+
+struct ff_effect;
+
+class LinuxForceFeedbackDevice
+{
+public:
+  LinuxForceFeedbackDevice(const std::string &device_path, rclcpp::Logger parent_logger);
+  ~LinuxForceFeedbackDevice();
+
+  void open();
+  void close();
+  bool isOpen() const;
+
+  void handleSetFeedback(const sensor_msgs::msg::JoyFeedbackArray::SharedPtr msg);
+
+private:
+  void initForceFeedback();
+  void uploadForceFeedback(const ff_effect &joy_effect);
+
+  rclcpp::Logger logger_;
+  std::string device_path_;
+  int fd_;
+};
+
+#endif // ROS2_JOY_LINUX_FORCE_FEEDBACK_HPP_INCLUDED

--- a/joy/include/joy/linux_helper.hpp
+++ b/joy/include/joy/linux_helper.hpp
@@ -1,0 +1,20 @@
+#ifndef ROS2_JOY_LINUX_HELPER_HPP_INCLUDED
+#define ROS2_JOY_LINUX_HELPER_HPP_INCLUDED
+
+#include "joystick_data.hpp"
+#include <rclcpp/logger.hpp>
+#include <string>
+#include <vector>
+
+struct LinuxJoystickData : public JoystickData
+{
+  std::string device_path;
+
+  std::string toBasicInfoString() const;
+};
+
+bool fillJoystickData(const std::string &device_path, LinuxJoystickData &data, rclcpp::Logger logger);
+
+std::vector<LinuxJoystickData> getJoysticks(rclcpp::Logger logger);
+
+#endif // ROS2_JOY_LINUX_HELPER_HPP_INCLUDED

--- a/joy/include/joy/linux_joystick.hpp
+++ b/joy/include/joy/linux_joystick.hpp
@@ -1,0 +1,40 @@
+#ifndef ROS2_JOY_LINUX_JOYSTICK_HPP_INCLUDED
+#define ROS2_JOY_LINUX_JOYSTICK_HPP_INCLUDED
+
+#include "joy_node.hpp"
+#include "linux_helper.hpp"
+#include <list>
+#include <memory>
+
+struct js_event;
+class LinuxForceFeedbackDevice;
+
+class LinuxJoystick : public JoyNode
+{
+public:
+    LinuxJoystick(rclcpp::NodeOptions options);
+    ~LinuxJoystick();
+
+private:
+    bool tryOpen(JoystickData &joystick_data);
+    void close();
+    bool isOpen() const;
+
+    ProcessEventsResult processEvents();
+    ProcessEventsResult processJoystickEvent(const js_event &event);
+    ProcessEventsResult checkInitEvents();
+
+    // force feedback
+    void handleSetFeedback(const sensor_msgs::msg::JoyFeedbackArray::SharedPtr msg);
+    std::unique_ptr<LinuxForceFeedbackDevice> force_feedback_device_;
+
+    // device information
+    std::string device_path_;
+    int fd_;
+
+    // initial events
+    std::list<unsigned> pending_axis_init_events_;
+    std::list<unsigned> pending_button_init_events_;
+};
+
+#endif // ROS2_JOY_LINUX_JOYSTICK_HPP_INCLUDED

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -1,200 +1,194 @@
-// Copyright 2009, 2020, Willow Garage, Inc., Joshua Whitley
-// All rights reserved.
-//
-// Software License Agreement (BSD License 2.0)
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-// * Redistributions of source code must retain the above copyright
-//   notice, this list of conditions and the following disclaimer.
-// * Redistributions in binary form must reproduce the above
-//   copyright notice, this list of conditions and the following
-//   disclaimer in the documentation and/or other materials provided
-//   with the distribution.
-// * Neither the name of {copyright_holder} nor the names of its
-//   contributors may be used to endorse or promote products derived
-//   from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
-// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
+/*
+ * teleop_pr2
+ * Copyright (c) 2009, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <ORGANIZATION> nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <dirent.h>
-#include <fcntl.h>
-#include <linux/joystick.h>
-#include <sys/stat.h>
-#include <unistd.h>
+//\author: Blaise Gassend
 
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/joy.hpp>
-#include <sensor_msgs/msg/joy_feedback_array.hpp>
+#include <joy/linux_joystick.hpp>
 
-#include <cstring>
-#include <string>
-
-#include "joy/joy_node.hpp"
-
-namespace joy
+int main(int argc, char **argv)
 {
+  rclcpp::init(argc, argv);
+
+  try {
+    auto joy_node = std::make_shared<LinuxJoystick>(rclcpp::NodeOptions());
+    joy_node->run();
+  }
+  catch (const std::exception &e) {
+    //
+  }
+
+  return rclcpp::shutdown() ? 0 : -1;
+}
 
 JoyNode::JoyNode(rclcpp::NodeOptions options)
-: Node("joy node", options),
+: Node("joy_node", options),
   joy_pub(this->create_publisher<sensor_msgs::msg::Joy>("joy", 1)),
   feedback_sub(this->create_subscription<sensor_msgs::msg::JoyFeedbackArray>(
-      "joy/set_feedback", 10, std::bind(&JoyNode::feedback_callback, this, std::placeholders::_1)))
+    "joy/set_feedback", 10, std::bind(&JoyNode::handleSetFeedback, this, std::placeholders::_1)))
 {
-  dev_path = this->declare_parameter("dev", "/dev/input/js0");
-  dev_ff_path = this->declare_parameter(
-    "ff_dev",
-    "/dev/input/by-id/usb-Sony_PLAYSTATION_R_3_Controller-event-joystick");
-  dev_name = this->declare_parameter("dev_name", "");
+  RCLCPP_INFO_STREAM(this->get_logger(), "Starting node " << this->get_name());
+
   deadzone = this->declare_parameter("deadzone", 0.05);
-  autorepeat_rate = this->declare_parameter("autorepeat_rate", 0);
+  autorepeat_rate = this->declare_parameter("autorepeat_rate", 0.0);
   coalesce_interval = this->declare_parameter("coalesce_interval", 0.001);
   // TODO(jwhitleyastuff): Make "default_trig_val actually do what we expect.
   sticky_buttons = this->declare_parameter("sticky_buttons", false);
 
-  if (!dev_name.empty()) {
-    std::string path = get_dev_path_by_name(dev_name);
-
-    if (path.empty()) {
-      RCLCPP_ERROR(
-        this->get_logger(),
-        "Couldn't find a joystick with name %s. Falling back to device path.",
-        dev_name.c_str());
-    } else {
-      RCLCPP_INFO(this->get_logger(), "Using %s as joystick device.", path.c_str());
-      dev_path = path;
-    }
-  }
-
   if (autorepeat_rate > (1.0 / coalesce_interval)) {
-    RCLCPP_WARN(
-      this->get_logger(),
+    RCLCPP_WARN(this->get_logger(),
       "autorepeat_rate (%f Hz) > 1 / coalesce_interval (%f Hz) does not make sense. "
       "Timing behavior is not well defined.",
-      autorepeat_rate,
-      1.0 / coalesce_interval);
+      autorepeat_rate, 1.0 / coalesce_interval);
   }
 
   if (deadzone >= 1) {
-    RCLCPP_WARN(
-      this->get_logger(),
-      "deadzone (%f) greater than 1.0, setting to 0.9. "
-      "If this was not intended, see the docs.",
-      deadzone);
+    RCLCPP_WARN(this->get_logger(), "deadzone (%f) greater than 1.0, setting to 0.9.", deadzone);
     deadzone = 0.9;
   } else if (deadzone > 0.9) {
-    RCLCPP_WARN(
-      this->get_logger(),
-      "deadzone (%f) greater than 0.9, setting to 0.9.",
-      deadzone);
+    RCLCPP_WARN(this->get_logger(), "deadzone (%f) greater than 0.9, setting to 0.9.", deadzone);
     deadzone = 0.9;
   } else if (deadzone < 0) {
-    RCLCPP_WARN(
-      this->get_logger(),
-      "deadzone (%f) less than 0, setting to 0.",
-      deadzone);
+    RCLCPP_WARN(this->get_logger(), "deadzone (%f) less than 0, setting to 0.", deadzone);
     deadzone = 0;
   }
+  deadzone_scale = -1.0 / (1.0 - deadzone) / 32767.0;
+  unscaled_deadzone = 32767.0 * deadzone;
 
   if (autorepeat_rate < 0) {
-    RCLCPP_WARN(
-      this->get_logger(),
-      "autorepeat_rate (%f) less than 0, setting to 0.",
-      autorepeat_rate);
-    autorepeat_rate = 0;
+    RCLCPP_WARN(this->get_logger(), "autorepeat_rate (%f) less than 0, setting to 0.", autorepeat_rate);
+    autorepeat_rate = 0; // 0 --> disable autorepeat
+  } else if (autorepeat_rate > 0) {
+    double autorepeat_interval = 1.0 / autorepeat_rate;
+    joy_pub_autorepeat_timer = this->create_wall_timer(std::chrono::microseconds(static_cast<long>(autorepeat_interval * 1e6)),
+                                                       [this]{ publish(); });
+    joy_pub_autorepeat_timer->cancel();
   }
 
   if (coalesce_interval < 0) {
-    RCLCPP_WARN(
-      this->get_logger(),
-      "coalesce_interval (%f) less than 0, setting to 0.",
-      coalesce_interval);
-    coalesce_interval = 0;
+    RCLCPP_WARN(this->get_logger(), "coalesce_interval (%f) less than 0, setting to 0.", coalesce_interval);
+    coalesce_interval = 0; // 0 --> publish immediately
+  } else if (coalesce_interval > 0) {
+    joy_pub_coalesce_timer = this->create_wall_timer(std::chrono::microseconds(static_cast<long>(coalesce_interval * 1e6)),
+                                                     [this]{ handleCoalesceTimerEvent(); });
+    joy_pub_coalesce_timer->cancel();
   }
 }
 
-void JoyNode::feedback_callback(const sensor_msgs::msg::JoyFeedbackArray::SharedPtr msg)
+JoyNode::~JoyNode()
 {
-  (void)msg;
+  RCLCPP_INFO(this->get_logger(), "Exiting node");
 }
 
-std::string JoyNode::get_dev_path_by_name(const std::string name)
+void JoyNode::run()
 {
-  const char path[] = "/dev/input";  // no trailing / here
-  struct dirent * entry;
-  struct stat stat_buf;
+  while (rclcpp::ok()) {
+    // Try to open the joystick
+    bool opened = false;
+    JoystickData joystick_data;
+    while (rclcpp::ok()) {
+      rclcpp::spin_some(this->shared_from_this());
+      opened = tryOpen(joystick_data);
+      if (opened) break;
+      RCLCPP_ERROR_STREAM_ONCE(this->get_logger(),
+        "Could not open joystick. Will retry every second.");
+      rclcpp::sleep_for(std::chrono::seconds(1));
+    }
 
-  DIR * dev_dir = opendir(path);
+    if (!opened) break;
+    RCLCPP_INFO_STREAM(this->get_logger(), "Opened joystick " << joystick_data.toBasicInfoString()
+                       << ". Deadzone: " << deadzone
+                       << " Autorepeat rate: " << autorepeat_rate
+                       << " Coalesce interval: " << coalesce_interval);
 
-  if (dev_dir == NULL) {
-    RCLCPP_ERROR(
-      this->get_logger(),
-      "Couldn't open %s. Error %i: %s.",
-      path, errno, strerror(errno));
-    return "";
+    // Prepare joy message for the specific device
+    joy_msg.axes.clear();
+    joy_msg.buttons.clear();
+    for (size_t i = 0; i < joystick_data.number_of_axes; ++i)
+      joy_msg.axes.emplace_back(0);
+    for (size_t i = 0; i < joystick_data.number_of_buttons; ++i)
+      joy_msg.buttons.emplace_back(0);
+
+    // Handle joystick events
+    while (rclcpp::ok()) {
+      rclcpp::spin_some(this->shared_from_this());
+      ProcessEventsResult result = processEvents();
+      if (result == ProcessEventsResult::Continue) {
+        continue;
+      } else if (result == ProcessEventsResult::PublishNow) {
+        publish();
+      } else if (result == ProcessEventsResult::PublishSoon) {
+        if (!joy_pub_coalesce_timer) {
+          publish();
+          if (joy_pub_autorepeat_timer) joy_pub_autorepeat_timer->reset();
+        }
+        else if (joy_pub_coalesce_timer->is_canceled()) {
+          if (joy_pub_autorepeat_timer) joy_pub_autorepeat_timer->cancel();
+          joy_pub_coalesce_timer->reset();
+        }
+      } else if (result == ProcessEventsResult::Abort)
+        break;
+    }
+
+    if (joy_pub_coalesce_timer) joy_pub_coalesce_timer->cancel();
+    if (joy_pub_autorepeat_timer) joy_pub_autorepeat_timer->cancel();
+    close();
   }
-
-  while ((entry = readdir(dev_dir)) != NULL) {
-    // filter entries
-    if (std::strncmp(entry->d_name, "js", 2) != 0) {  // skip device if it's not a joystick
-      continue;
-    }
-
-    std::string current_path = std::string(path) + "/" + entry->d_name;
-
-    if (stat(current_path.c_str(), &stat_buf) == -1) {
-      continue;
-    }
-
-    if (!S_ISCHR(stat_buf.st_mode)) {  // input devices are character devices, skip other
-      continue;
-    }
-
-    // get joystick name
-    int joy_fd = open(current_path.c_str(), O_RDONLY);
-
-    if (joy_fd == -1) {
-      continue;
-    }
-
-    char current_joy_name[128];
-
-    if (ioctl(joy_fd, JSIOCGNAME(sizeof(current_joy_name)), current_joy_name) < 0) {
-      std::strncpy(current_joy_name, "Unknown", sizeof(current_joy_name));
-    }
-
-    close(joy_fd);
-
-    RCLCPP_INFO(
-      this->get_logger(),
-      "Found joystick: %s (%s).",
-      current_joy_name,
-      current_path.c_str());
-
-    if (std::strcmp(current_joy_name, name.c_str()) == 0) {
-      closedir(dev_dir);
-      return current_path;
-    }
-  }
-
-  closedir(dev_dir);
-  return "";
 }
 
-}  // namespace joy
+void JoyNode::startAutorepeatPublishing()
+{
+  if (joy_pub_autorepeat_timer) {
+    RCLCPP_INFO(this->get_logger(), "Starting autorepeat publishing");
+    joy_pub_autorepeat_timer->reset();
+  }
+}
 
-#include <rclcpp_components/register_node_macro.hpp>  // NOLINT
-RCLCPP_COMPONENTS_REGISTER_NODE(joy::JoyNode)
+void JoyNode::updateButton(size_t button, int32_t value)
+{
+  joy_msg.buttons.at(button) = value;
+}
+
+void JoyNode::updateAxis(size_t axis, float value)
+{
+  joy_msg.axes.at(axis) = value;
+}
+
+void JoyNode::publish()
+{
+  joy_msg.header.stamp = joy_clock.now();
+  joy_pub->publish(joy_msg);
+}
+
+void JoyNode::handleCoalesceTimerEvent()
+{
+  joy_pub_coalesce_timer->cancel();
+  if (joy_pub_autorepeat_timer) joy_pub_autorepeat_timer->reset();
+  publish();
+}

--- a/joy/src/joystick_data.cpp
+++ b/joy/src/joystick_data.cpp
@@ -1,0 +1,13 @@
+#include <joy/joystick_data.hpp>
+
+std::string JoystickData::toBasicInfoString() const
+{
+  return device_name;
+}
+
+std::string JoystickData::toDetailInfoString() const
+{
+  return toBasicInfoString() + ", "
+          + std::to_string(number_of_axes) + " axes, "
+          + std::to_string(number_of_buttons) + " buttons";
+}

--- a/joy/src/linux_force_feedback.cpp
+++ b/joy/src/linux_force_feedback.cpp
@@ -1,0 +1,125 @@
+#include <joy/linux_force_feedback.hpp>
+
+#include <fcntl.h>
+#include <linux/joystick.h>
+#include <rclcpp/logging.hpp>
+#include <sstream>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+LinuxForceFeedbackDevice::LinuxForceFeedbackDevice(const std::string &device_path, rclcpp::Logger parent_logger)
+: logger_(parent_logger.get_child("feedback")),
+  device_path_(device_path),
+  fd_(-1)
+{
+
+}
+
+LinuxForceFeedbackDevice::~LinuxForceFeedbackDevice()
+{
+  close();
+}
+
+void LinuxForceFeedbackDevice::open()
+{
+  if (isOpen()) {
+    RCLCPP_ERROR_STREAM(logger_, "Device already open: " << device_path_);
+    return;
+  }
+
+  fd_ = ::open(device_path_.c_str(), O_RDWR);
+  if (fd_ == -1) {
+      RCLCPP_ERROR_STREAM(logger_, "Cannot open device " << device_path_
+                          << ". Error " << errno << ": " << strerror(errno));
+  } else {
+    initForceFeedback();
+  }
+}
+
+void LinuxForceFeedbackDevice::close()
+{
+  if (isOpen()) {
+    ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+bool LinuxForceFeedbackDevice::isOpen() const
+{
+  return fd_ != -1;
+}
+
+void LinuxForceFeedbackDevice::initForceFeedback()
+{
+  /* Set the gain of the device*/
+  int gain = 100;           /* between 0 and 100 */
+  struct input_event ie;      /* structure used to communicate with the driver */
+  ie.type = EV_FF;
+  ie.code = FF_GAIN;
+  ie.value = 0xFFFFUL * gain / 100;
+
+  if (::write(fd_, &ie, sizeof(ie)) == -1) {
+    RCLCPP_ERROR_STREAM(logger_, "Could not write joystick force feedback"
+                        << ". Error " << errno << ": " << strerror(errno));
+    return;
+  }
+
+  struct ff_effect joy_effect;
+  joy_effect.id = -1;//0;
+  joy_effect.direction = 0;//down
+  joy_effect.type = FF_RUMBLE;
+  joy_effect.u.rumble.strong_magnitude = 0;
+  joy_effect.u.rumble.weak_magnitude = 0;
+  joy_effect.replay.length = 1000;
+  joy_effect.replay.delay = 0;
+
+  uploadForceFeedback(joy_effect);
+}
+
+void LinuxForceFeedbackDevice::uploadForceFeedback(const ff_effect &joy_effect)
+{
+  struct input_event ie;
+  ie.type = EV_FF;
+  ie.code = joy_effect.id;
+  ie.value = 3; // TODO: magic number?
+
+  if (::write(fd_, &ie, sizeof(ie)) == -1) {
+    RCLCPP_ERROR_STREAM(logger_, "Could not write joystick force feedback"
+                        << ". Error " << errno << ": " << strerror(errno));
+    return;
+  }
+
+  // upload the effect
+  if (::ioctl(fd_, EVIOCSFF, &joy_effect) == -1) {
+    RCLCPP_ERROR_STREAM(logger_, "Could not upload joystick force feedback"
+                        << ". Error " << errno << ": " << strerror(errno));
+  }
+}
+
+void LinuxForceFeedbackDevice::handleSetFeedback(const sensor_msgs::msg::JoyFeedbackArray::SharedPtr msg)
+{
+  if (!isOpen()) return;
+
+  for (const sensor_msgs::msg::JoyFeedback &effect : msg->array) {
+    switch (effect.type) {
+      case sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE:
+        struct ff_effect joy_effect;
+
+        joy_effect.direction = 0; // 0 = down
+        joy_effect.type = FF_RUMBLE;
+        if (effect.id == 0)
+          joy_effect.u.rumble.strong_magnitude = ((float)(1<<15)) * effect.intensity;
+        else
+          joy_effect.u.rumble.weak_magnitude = ((float)(1<<15)) * effect.intensity;
+
+        joy_effect.replay.length = 1000;
+        joy_effect.replay.delay = 0;
+
+        uploadForceFeedback(joy_effect);
+        break;
+      default:
+        RCLCPP_WARN_STREAM_ONCE(logger_, "Force feedback effect with type=" << effect.type << " not implemented, yet."
+                                << " Won't report any further missed effects.");
+    }
+  }
+}

--- a/joy/src/linux_helper.cpp
+++ b/joy/src/linux_helper.cpp
@@ -1,0 +1,118 @@
+#include <joy/linux_helper.hpp>
+
+#include <cstring>
+#include <dirent.h>
+#include <fcntl.h>
+#include <functional>
+#include <linux/joystick.h>
+#include <rclcpp/logging.hpp>
+#include <sstream>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+class Defer
+{
+public:
+  Defer(std::function<void (void)> f) : f_(f) {}
+  ~Defer() { f_(); }
+private:
+  std::function<void (void)> f_;
+};
+
+bool isCharacterDeviceFile(const std::string &path)
+{
+  struct stat statbuf;
+  if (::stat(path.c_str(), &statbuf) == 0) {
+    return S_ISCHR(statbuf.st_mode); // input devices are character devices
+  }
+  return false;
+}
+
+std::string LinuxJoystickData::toBasicInfoString() const
+{
+  return device_name + " (" + device_path + ")";
+}
+
+bool fillJoystickData(const std::string &device_path, LinuxJoystickData &data, rclcpp::Logger logger)
+{
+  if (!isCharacterDeviceFile(device_path)) return false;
+
+  int fd = ::open(device_path.c_str(), O_RDONLY);
+  if (fd == -1) {
+    RCLCPP_ERROR_STREAM(logger, "Cannot open " << device_path
+                        << ". Error " << errno << ": " << strerror(errno));
+    return false;
+  }
+  Defer deferred_close([&]{ ::close(fd); });
+
+  data.device_path = device_path;
+
+  // get number of axes
+  int ioctl_result;
+  char number_of_axes;
+  ioctl_result = ::ioctl(fd, JSIOCGAXES, &number_of_axes);
+  if (ioctl_result == -1) {
+    RCLCPP_ERROR_STREAM(logger, "Cannot get number of axes from " << device_path
+                        << ". Error " << errno << ": " << strerror(errno));
+    return false;
+  }
+  data.number_of_axes = number_of_axes;
+
+  // get number of buttons
+  char number_of_buttons;
+  ioctl_result = ::ioctl(fd, JSIOCGBUTTONS, &number_of_buttons);
+  if (ioctl_result == -1) {
+    RCLCPP_ERROR_STREAM(logger, "Cannot get number of buttons from " << device_path
+                        << ". Error " << errno << ": " << strerror(errno));
+    return false;
+  }
+  data.number_of_buttons = number_of_buttons;
+
+  // get joystick name
+  char joystick_name[128];
+  ioctl_result = ::ioctl(fd, JSIOCGNAME(sizeof(joystick_name)), joystick_name);
+  // TODO: ioctl_result seems to be the length of joystick_name including the trailing zero.
+  // Could it be used to detect if the provided buffer was too small to hold the full name?
+  // (The return value for JSIOCGNAME is not documented, maybe this is driver specific.)
+  if (ioctl_result == -1) {
+      RCLCPP_ERROR_STREAM(logger, "Cannot get device name from " << device_path
+                          << ". Error " << errno << ": " << strerror(errno));
+      return false;
+  }
+  data.device_name = joystick_name;
+
+  return true;
+}
+
+std::vector<LinuxJoystickData> getJoysticks(rclcpp::Logger logger)
+{
+  std::string path = "/dev/input/";
+  std::vector<LinuxJoystickData> joysticks;
+  struct dirent *entry;
+
+  DIR *dev_dir = ::opendir(path.c_str());
+  if (dev_dir == NULL) {
+    RCLCPP_ERROR_STREAM(logger, "Cannot open " << path
+                        << ". Error " << errno << ": " << strerror(errno));
+    return joysticks;
+  }
+  Defer deffered_close_dir([&]{ ::closedir(dev_dir); });
+
+  while ((entry = readdir(dev_dir)) != NULL) {
+    // filter entries
+    if (std::strncmp(entry->d_name, "js", 2) != 0) {  // skip device if it's not a joystick
+      continue;
+    }
+
+    std::string current_path = path + entry->d_name;
+    LinuxJoystickData joystick_data;
+    if (fillJoystickData(current_path, joystick_data, logger)) {
+      RCLCPP_INFO_STREAM(logger, "Found joystick: " << joystick_data.toDetailInfoString());
+      joysticks.push_back(joystick_data);
+    }
+  }
+
+  return joysticks;
+}

--- a/joy/src/linux_joystick.cpp
+++ b/joy/src/linux_joystick.cpp
@@ -1,0 +1,180 @@
+#include <joy/linux_joystick.hpp>
+#include <joy/linux_force_feedback.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <fcntl.h>
+#include <linux/joystick.h>
+#include <stdexcept>
+#include <unistd.h>
+
+// forward declarations
+bool isCharacterDeviceFile(const std::string &filepath);
+bool getJoystickName(const std::string &device_file, std::string &joystick_name);
+
+LinuxJoystick::LinuxJoystick(rclcpp::NodeOptions options)
+: JoyNode(options),
+  fd_(-1)
+{
+  static constexpr char DEFAULT_DEVICE[] = "/dev/input/js0";
+
+  device_path_ = this->declare_parameter("device", "");
+
+  if (device_path_.empty()) {
+    // if no device path was specified, check for device_name
+    std::string device_name = this->declare_parameter("device_name", "");
+    if (device_name.empty()) {
+      device_path_ = DEFAULT_DEVICE;
+      RCLCPP_WARN_STREAM(this->get_logger(),
+        "Neither device nor device_name were specified, will use default device: " << device_path_);
+    } else {
+      // enumerate all joysticks and check if one matches device_name
+      RCLCPP_INFO_STREAM(this->get_logger(), "Looking for joystick with name: " << device_name);
+      std::vector<LinuxJoystickData> joysticks = getJoysticks(this->get_logger());
+      auto joystick_it = std::find_if(joysticks.begin(), joysticks.end(),
+        [&device_name](const LinuxJoystickData &data){ return data.device_name == device_name; });
+      if (joystick_it != joysticks.end()) { // found a joystick matching device_name
+        device_path_ = joystick_it->device_path;
+        RCLCPP_INFO_STREAM(this->get_logger(), "Will use device: " << device_path_);
+      } else {
+        device_path_ = DEFAULT_DEVICE;
+        RCLCPP_WARN_STREAM(this->get_logger(),
+          "Joystick with name " << device_name << " not found, will use default device: " << device_path_);
+      }
+    }
+  }
+
+  std::string ff_device = this->declare_parameter("ff_device", "");
+  if (!ff_device.empty()) {
+    force_feedback_device_ = std::make_unique<LinuxForceFeedbackDevice>(ff_device, this->get_logger());
+  }
+}
+
+LinuxJoystick::~LinuxJoystick()
+{
+  close();
+}
+
+bool LinuxJoystick::tryOpen(JoystickData &joystick_data)
+{
+  // There seems to be a bug in the driver or something where the
+  // initial events that are to define the initial state of the
+  // joystick are not the values of the joystick when it was opened
+  // but rather the values of the joystick when it was last closed.
+  // Opening then closing and opening again is a hack to get more
+  // accurate initial state data.
+
+  // fillJoystickData will open and close the device
+  LinuxJoystickData linux_joystick_data;
+  if (!fillJoystickData(device_path_, linux_joystick_data, this->get_logger())) {
+    return false;
+  }
+  joystick_data = linux_joystick_data;
+
+  for (size_t i = 0; i < linux_joystick_data.number_of_axes; ++i)
+    pending_axis_init_events_.emplace_back(i);
+  for (size_t i = 0; i < linux_joystick_data.number_of_buttons; ++i)
+    pending_button_init_events_.emplace_back(i);
+
+  fd_ = ::open(device_path_.c_str(), O_RDONLY);
+  if (fd_ == -1) {
+    RCLCPP_ERROR_STREAM(this->get_logger(), "Cannot open " << device_path_
+                        << ". Error " << errno << ": " << strerror(errno));
+    return false;
+  }
+
+  if (force_feedback_device_) force_feedback_device_->open();
+
+  return true;
+}
+
+void LinuxJoystick::close()
+{
+  if (isOpen()) {
+    ::close(fd_);
+    RCLCPP_INFO(this->get_logger(), "Joystick closed");
+    fd_ = -1;
+  }
+}
+
+bool LinuxJoystick::isOpen() const
+{
+  return fd_ != -1;
+}
+
+void LinuxJoystick::handleSetFeedback(const sensor_msgs::msg::JoyFeedbackArray::SharedPtr msg)
+{
+  if (force_feedback_device_) force_feedback_device_->handleSetFeedback(msg);
+}
+
+ProcessEventsResult LinuxJoystick::processEvents()
+{
+  struct timeval timeout;
+  timeout.tv_sec = 1;
+  timeout.tv_usec = 0;
+
+  fd_set set;
+  FD_ZERO(&set);
+  FD_SET(fd_, &set);
+
+  int select_result = ::select(fd_ + 1, &set, nullptr, nullptr, &timeout);
+  if (select_result > 0 && FD_ISSET(fd_, &set)) { // the file descriptor has data to read
+    js_event event;
+    if (::read(fd_, &event, sizeof(event)) == -1) {
+      if (errno == EAGAIN) { // read would block
+        return ProcessEventsResult::Continue; // try again
+      } else if (errno == EINTR) { // read was interrupted by a signal
+        return ProcessEventsResult::Abort;
+      }
+      RCLCPP_ERROR_STREAM(this->get_logger(), "Error " << errno << " while reading from the joystick device: " << strerror(errno));
+      return ProcessEventsResult::Abort;
+    }
+
+    return processJoystickEvent(event);
+  } else if (select_result == 0) { // a timeout occured
+    return ProcessEventsResult::Continue;
+  } else if (select_result < 0) { // an error occured
+    if (errno == EINTR) { // select was interrupted by a signal
+      return ProcessEventsResult::Abort;
+    }
+    RCLCPP_ERROR_STREAM(this->get_logger(), "Error " << errno << " while waiting for the joystick device: " << strerror(errno));
+    return ProcessEventsResult::Abort;
+  }
+
+  // in all other cases: continue
+  return ProcessEventsResult::Continue;
+}
+
+ProcessEventsResult LinuxJoystick::processJoystickEvent(const js_event &event)
+{
+  switch (event.type) {
+    case JS_EVENT_AXIS:
+      updateAxis(event.number, event.value);
+      return ProcessEventsResult::PublishSoon;
+    case JS_EVENT_BUTTON:
+      updateButton(event.number, (event.value ? 1:0));
+      return ProcessEventsResult::PublishNow;
+    case JS_EVENT_BUTTON | JS_EVENT_INIT:
+      updateButton(event.number, (event.value ? 1:0));
+      pending_button_init_events_.remove(event.number);
+      //RCLCPP_INFO_STREAM(this->get_logger(), "Button Init " << +event.number);
+      return checkInitEvents();
+    case JS_EVENT_AXIS | JS_EVENT_INIT:
+      updateAxis(event.number, event.value);
+      pending_axis_init_events_.remove(event.number);
+      //RCLCPP_INFO_STREAM(this->get_logger(), "Axis Init " << +event.number);
+      return checkInitEvents();
+  }
+
+  return ProcessEventsResult::Continue;
+}
+
+ProcessEventsResult LinuxJoystick::checkInitEvents()
+{
+  if (pending_axis_init_events_.empty() && pending_button_init_events_.empty()) {
+    //RCLCPP_INFO(this->get_logger(), "All init events received");
+    startAutorepeatPublishing();
+    return ProcessEventsResult::PublishNow;
+  }
+  return ProcessEventsResult::Continue;
+}


### PR DESCRIPTION
I needed a joystick driver for ROS 2 and therefore tried the ros2 branch. After some testing I realised that the actual implementation is still missing :)

@JWhitleyWork I implemented the basic functionality and prepared a generic interface that can be used by the Mac and Windows implementations as well. At the moment, the following features are still missing:
- Deadzone
- Sticky buttons
- Default trigger value
- Documentation
- Windows and Mac implementation

The node can be run like this:
```
joy_node --ros-args -r __node:=my_joy -p device_name:="Microsoft X-Box 360 pad" -p coalesce_interval:=0.01 -p autorepeat_rate:=0.5
```

`device_name` can be replaced with `device:=/dev/input/jsX`