### PR TITLE
ROS1 joy cleanups

### DIFF
--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -56,7 +56,7 @@ private:
   bool default_trig_val_;
   std::string joy_dev_;
   std::string joy_dev_name_;
-  std::string joy_def_ff_;
+  std::string joy_dev_ff_;
   double deadzone_;
   double autorepeat_rate_;   // in Hz.  0 for no repeat.
   double coalesce_interval_; // Defaults to 100 Hz rate limit.
@@ -210,7 +210,7 @@ public:
     pub_ = nh_.advertise<sensor_msgs::Joy>("joy", 1);
     ros::Subscriber sub = nh_.subscribe("joy/set_feedback", 10, &Joystick::set_feedback, this);
     nh_param.param<std::string>("dev", joy_dev_, "/dev/input/js0");
-    nh_param.param<std::string>("dev_ff", joy_def_ff_, "/dev/input/by-id/usb-Sony_PLAYSTATION_R_3_Controller-event-joystick");
+    nh_param.param<std::string>("dev_ff", joy_dev_ff_, "/dev/input/by-id/usb-Sony_PLAYSTATION_R_3_Controller-event-joystick");
     nh_param.param<std::string>("dev_name", joy_dev_name_, "");
     nh_param.param<double>("deadzone", deadzone_, 0.05);
     nh_param.param<double>("autorepeat_rate", autorepeat_rate_, 0);
@@ -319,9 +319,9 @@ public:
         diagnostic_.update();
       }
 
-      if (joy_def_ff_.length())
+      if (joy_dev_ff_.length())
       {
-        ff_fd_ = open(joy_def_ff_.c_str(), O_RDWR);
+        ff_fd_ = open(joy_dev_ff_.c_str(), O_RDWR);
 
         /* Set the gain of the device*/
         int gain = 100;           /* between 0 and 100 */

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -319,7 +319,7 @@ public:
         diagnostic_.update();
       }
 
-      if (joy_dev_ff_.length())
+      if (!joy_dev_ff_.empty())
       {
         ff_fd_ = open(joy_dev_ff_.c_str(), O_RDWR);
 

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -210,7 +210,7 @@ public:
     pub_ = nh_.advertise<sensor_msgs::Joy>("joy", 1);
     ros::Subscriber sub = nh_.subscribe("joy/set_feedback", 10, &Joystick::set_feedback, this);
     nh_param.param<std::string>("dev", joy_dev_, "/dev/input/js0");
-    nh_param.param<std::string>("dev_ff", joy_dev_ff_, "/dev/input/by-id/usb-Sony_PLAYSTATION_R_3_Controller-event-joystick");
+    nh_param.param<std::string>("dev_ff", joy_dev_ff_, "/dev/input/event0");
     nh_param.param<std::string>("dev_name", joy_dev_name_, "");
     nh_param.param<double>("deadzone", deadzone_, 0.05);
     nh_param.param<double>("autorepeat_rate", autorepeat_rate_, 0);
@@ -333,7 +333,7 @@ public:
 
         if (write(ff_fd_, &ie, sizeof(ie)) == -1)
         {
-          ROS_ERROR("Couldn't open joystick force feedback!");//perror("set gain");
+          ROS_WARN("Couldn't set gain on joystick force feedback: %s", strerror(errno));
         }
 
         joy_effect_.id = -1;//0;

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -184,11 +184,11 @@ public:
         joy_effect_.type = FF_RUMBLE;
         if (msg->array[i].id == 0)
         {
-          joy_effect_.u.rumble.strong_magnitude = ((float)(1<<15))*msg->array[i].intensity;
+          joy_effect_.u.rumble.strong_magnitude = (static_cast<float>(1<<15))*msg->array[i].intensity;
         }
         else
         {
-          joy_effect_.u.rumble.weak_magnitude = ((float)(1<<15))*msg->array[i].intensity;
+          joy_effect_.u.rumble.weak_magnitude = (static_cast<float>(1<<15))*msg->array[i].intensity;
         }
 
         joy_effect_.replay.length = 1000;

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -109,13 +109,13 @@ private:
     struct stat stat_buf;
 
     DIR *dev_dir = opendir(path);
-    if (dev_dir == NULL)
+    if (dev_dir == nullptr)
     {
       ROS_ERROR("Couldn't open %s. Error %i: %s.", path, errno, strerror(errno));
       return "";
     }
 
-    while ((entry = readdir(dev_dir)) != NULL)
+    while ((entry = readdir(dev_dir)) != nullptr)
     {
       // filter entries
       if (strncmp(entry->d_name, "js", 2) != 0) // skip device if it's not a joystick
@@ -368,7 +368,7 @@ public:
         FD_SET(joy_fd, &set);
 
         //ROS_INFO("Select...");
-        int select_out = select(joy_fd+1, &set, NULL, NULL, &tv);
+        int select_out = select(joy_fd+1, &set, nullptr, nullptr, &tv);
         //ROS_INFO("Tick...");
         if (select_out == -1)
         {

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -30,18 +30,20 @@
 
 //\author: Blaise Gassend
 
-#include <unistd.h>
-#include <math.h>
-#include <linux/joystick.h>
-#include <fcntl.h>
-#include <sys/stat.h>
+#include <string>
+
 #include <dirent.h>
+#include <fcntl.h>
+#include <linux/input.h>
+#include <linux/joystick.h>
+#include <math.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include <diagnostic_updater/diagnostic_updater.h>
-#include "ros/ros.h"
+#include <ros/ros.h>
 #include <sensor_msgs/Joy.h>
 #include <sensor_msgs/JoyFeedbackArray.h>
-#include <linux/input.h>
-#include <unistd.h>
 
 
 ///\brief Opens, reads from and publishes joystick events

--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -171,8 +171,8 @@ public:
       return;//we arent ready yet
     }
 
-    int size = msg->array.size();
-    for (int i = 0; i < size; i++)
+    size_t size = msg->array.size();
+    for (size_t i = 0; i < size; i++)
     {
       //process each feedback
       if (msg->array[i].type == 1 && ff_fd_ != -1)//TYPE_RUMBLE
@@ -415,11 +415,11 @@ public:
           case JS_EVENT_BUTTON | JS_EVENT_INIT:
             if (event.number >= joy_msg.buttons.size())
             {
-              int old_size = joy_msg.buttons.size();
+              size_t old_size = joy_msg.buttons.size();
               joy_msg.buttons.resize(event.number+1);
               last_published_joy_msg.buttons.resize(event.number+1);
               sticky_buttons_joy_msg.buttons.resize(event.number+1);
-              for (unsigned int i = old_size; i < joy_msg.buttons.size(); i++)
+              for (size_t i = old_size; i < joy_msg.buttons.size(); i++)
               {
                 joy_msg.buttons[i] = 0.0;
                 last_published_joy_msg.buttons[i] = 0.0;
@@ -443,11 +443,11 @@ public:
             val = event.value;
             if (event.number >= joy_msg.axes.size())
             {
-              int old_size = joy_msg.axes.size();
+              size_t old_size = joy_msg.axes.size();
               joy_msg.axes.resize(event.number+1);
               last_published_joy_msg.axes.resize(event.number+1);
               sticky_buttons_joy_msg.axes.resize(event.number+1);
-              for (unsigned int i = old_size; i < joy_msg.axes.size(); i++)
+              for (size_t i = old_size; i < joy_msg.axes.size(); i++)
               {
                 joy_msg.axes[i] = 0.0;
                 last_published_joy_msg.axes[i] = 0.0;


### PR DESCRIPTION
This set of patches is various cleanups to the ROS 1 joystick driver.  The easiest way to review them is patch-by-patch, as each one does a targeted thing.  I tested on my Logitech F710 joystick, and it all still seems to work after these patches.

Comments, questions, and reviews appreciated!