### PR TITLE
Make sure to import struct where it is used.

### DIFF
--- a/ps3joy/scripts/ps3joy_node.py
+++ b/ps3joy/scripts/ps3joy_node.py
@@ -38,6 +38,7 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 
 from bluetooth import *
 import select
+import struct
 import fcntl
 import os
 import time

--- a/ps3joy/scripts/ps3joysim.py
+++ b/ps3joy/scripts/ps3joysim.py
@@ -36,6 +36,7 @@ from bluetooth import *
 import select
 import fcntl
 import os
+import struct
 import time
 import sys
 import traceback


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

As mentioned in https://github.com/ros-drivers/joystick_drivers/pull/161#discussion_r403728089 , make sure to import struct where we use it.  I don't have a PS3 joystick, so I can't test this.