### PR TITLE
joy: Little fixes for force feedback.

### DIFF
--- a/joy/src/joy_node.cpp
+++ b/joy/src/joy_node.cpp
@@ -184,11 +184,11 @@ public:
         joy_effect_.type = FF_RUMBLE;
         if (msg->array[i].id == 0)
         {
-          joy_effect_.u.rumble.strong_magnitude = (static_cast<float>(1<<15))*msg->array[i].intensity;
+          joy_effect_.u.rumble.strong_magnitude = (static_cast<float>(0xFFFFU))*msg->array[i].intensity;
         }
         else
         {
-          joy_effect_.u.rumble.weak_magnitude = (static_cast<float>(1<<15))*msg->array[i].intensity;
+          joy_effect_.u.rumble.weak_magnitude = (static_cast<float>(0xFFFFU))*msg->array[i].intensity;
         }
 
         joy_effect_.replay.length = 1000;
@@ -339,6 +339,7 @@ public:
           ROS_WARN("Couldn't set gain on joystick force feedback: %s", strerror(errno));
         }
 
+        memset(&joy_effect_, 0, sizeof(joy_effect_));
         joy_effect_.id = -1;
         joy_effect_.direction = 0;  // down
         joy_effect_.type = FF_RUMBLE;
@@ -384,7 +385,7 @@ public:
           struct input_event start;
           start.type = EV_FF;
           start.code = joy_effect_.id;
-          start.value = 3;
+          start.value = 1;
           if (write(ff_fd_, (const void*) &start, sizeof(start)) == -1)
           {
             break;  // fd closed


### PR DESCRIPTION
This PR increases the maximum magnitude of the FF effects to double the previous maximum. The `rumble.strong_magnitude` is `unsigned short`, so the max value is `1 << 16 - 1`, or `0xFFFF`, while the previous code only allowed `0` to `1 << 15`.

The zeroing of memory is just for sure, but it is even mentioned in the official guide on https://www.kernel.org/doc/html/latest/input/ff.html .

That guide is also the source of the magic number 3 on the event start value. But according to the guide, the number means the number of repetitions of the effect, and 3 is there just as an example. I think 1 is much more appropriate.

I tested the PR with Logitech F710 and it helped to get stronger feedback. Before, the strong magnitude was barely feelable even when maxxed to 1.0 in the ROS message.