### PR TITLE
Change force feedback logger comment from ERROR to WARN

### DIFF
--- a/joy_linux/src/joy_linux_node.cpp
+++ b/joy_linux/src/joy_linux_node.cpp
@@ -346,7 +346,7 @@ public:
         ie.value = 0xFFFFUL * gain / 100;
 
         if (write(ff_fd_, &ie, sizeof(ie)) == -1) {
-          RCLCPP_ERROR(
+          RCLCPP_WARN(
             node_->get_logger(), "Couldn't open joystick force feedback: %s", strerror(errno));
         }
 


### PR DESCRIPTION
I ran into https://github.com/ros-drivers/joystick_drivers/issues/146 while testing some ros2 stuff and got pretty confused by it.

The fix seems trivial, so here is a PR to fix it, at least for the ros2 branch.

I couldn't find a contributors guide file for this repo, so please let me know what I need to do to get this in :)