### PR TITLE
Fix SDL2 include path

### DIFF
--- a/joy/include/joy/joy.hpp
+++ b/joy/include/joy/joy.hpp
@@ -30,7 +30,7 @@
 #ifndef JOY__JOY_HPP_
 #define JOY__JOY_HPP_
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>

--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>

--- a/joy/src/joy_enumerate_devices.cpp
+++ b/joy/src/joy_enumerate_devices.cpp
@@ -29,7 +29,7 @@
 
 // On Windows, we have to be sure that SDL doesn't generate its own main.
 #define SDL_MAIN_HANDLED
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <cstdio>
 #include <stdexcept>


### PR DESCRIPTION
The CMake functionality provided by SDL2 specifies that the include directory is the `SDL2` directory itself, not the parent directory thereof. On some systems, we're getting lucky because the SDL2 directory resides in a common include directory like `/usr/include`, so the include directory given by the SDL2 CMake functionality isn't used. Of course, on systems where this is not the case, the compiler fails to find the headers.

This should resolve the CI build failure on macOS.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13641)](http://ci.ros2.org/job/ci_linux/13641/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8521)](http://ci.ros2.org/job/ci_linux-aarch64/8521/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11356)](http://ci.ros2.org/job/ci_osx/11356/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13704)](http://ci.ros2.org/job/ci_windows/13704/)