### PR TITLE
fix compile error caused by missing include

### DIFF
--- a/wiimote/include/wiimote/stat_vector_3d.hpp
+++ b/wiimote/include/wiimote/stat_vector_3d.hpp
@@ -29,7 +29,6 @@
 #ifndef WIIMOTE__STAT_VECTOR_3D_HPP_
 #define WIIMOTE__STAT_VECTOR_3D_HPP_
 
-#include <stdexcept>
 #include <vector>
 
 // The vector of 3 values collected to generate:

--- a/wiimote/include/wiimote/stat_vector_3d.hpp
+++ b/wiimote/include/wiimote/stat_vector_3d.hpp
@@ -29,7 +29,7 @@
 #ifndef WIIMOTE__STAT_VECTOR_3D_HPP_
 #define WIIMOTE__STAT_VECTOR_3D_HPP_
 
-
+#include <stdexcept>
 #include <vector>
 
 // The vector of 3 values collected to generate:

--- a/wiimote/src/stat_vector_3d.cpp
+++ b/wiimote/src/stat_vector_3d.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <functional>
 #include <numeric>
+#include <stdexcept>
 
 StatVector3d::StatVector3d() {count_ = 0;}
 


### PR DESCRIPTION
`stat_vector_3d.cpp` uses `std::runtime_error`, which is included in `stdexcept`

I couldn't build joystick_drivers without it