### PR TITLE
Fix a warning while building wiimote_controller.cpp

### DIFF
--- a/wiimote/src/wiimote_controller.cpp
+++ b/wiimote/src/wiimote_controller.cpp
@@ -363,7 +363,7 @@ bool WiimoteNode::pair_wiimote(int flags = 0, int timeout = 5)
     status = false;
   } else {
     RCLCPP_INFO(logger_, "Paired to %s.", get_bluetooth_addr());
-    RCLCPP_INFO(logger_, "Calibrating device...", get_bluetooth_addr());
+    RCLCPP_INFO(logger_, "Calibrating device...");
     RCLCPP_INFO(logger_, "Allow all joy sticks to remain at center position until calibrated.");
     // Give the hardware time to zero the accelerometer and gyro after pairing
     // Ensure we are getting valid data before using


### PR DESCRIPTION
gcc is warning that there are too many arguments for the
printf-like RCLCPP_INFO, and it is correct.  Fix that here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>