### PR TITLE
Make nodes runnable on Noetic

### DIFF
--- a/ps3joy/CMakeLists.txt
+++ b/ps3joy/CMakeLists.txt
@@ -45,6 +45,9 @@ install(FILES diagnostics.yaml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS scripts/ps3joy.py scripts/ps3joy_node.py scripts/ps3joysim.py
+catkin_install_python(PROGRAMS
+  scripts/ps3joy.py
+  scripts/ps3joy_node.py
+  scripts/ps3joysim.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/ps3joy/package.xml
+++ b/ps3joy/package.xml
@@ -30,7 +30,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>joystick</depend>
   <depend>libusb-dev</depend>
-  <depend>python-bluez</depend>
+  <depend>python3-bluez</depend>
   <depend>rosgraph</depend>
   <depend>rospy</depend>
   <depend>sensor_msgs</depend>

--- a/wiimote/CMakeLists.txt
+++ b/wiimote/CMakeLists.txt
@@ -83,7 +83,10 @@ install(DIRECTORY launch/
 )
 
 # Install targets
-install(PROGRAMS nodes/feedbackTester.py  nodes/wiimote_node.py
+catkin_install_python(
+  PROGRAMS
+  nodes/feedbackTester.py
+  nodes/wiimote_node.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   )
 ## Mark executables and/or libraries for installation


### PR DESCRIPTION
This fixes the dependency listing and installation of python scripts so that they are compatible with Python3 that is used in ROS Noetic.

Depends on https://github.com/ros/rosdistro/pull/28495

This PR does not include any fixes to the python code itself that may also not be compatible with python3 (e.g. https://github.com/ros-drivers/joystick_drivers/issues/200)