### PR TITLE
Switch action-ros-ci to 0.2.0.

### DIFF
--- a/.github/workflows/basic-build-ci.yaml
+++ b/.github/workflows/basic-build-ci.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-foxy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
     container:
@@ -23,8 +23,7 @@ jobs:
           sdl2_vendor
           wiimote
           wiimote_msgs
-        source-ros-binary-installation: foxy
-        vcs-repo-file-url: ""
+        target-ros2-distro: foxy
     - name: Upload logs
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/basic-build-ci.yaml
+++ b/.github/workflows/basic-build-ci.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Fix Bugs in ros-tooling/action-ros-ci
       run: sudo chown -R rosbuild:rosbuild "$HOME" .
     - name: Run Tests
-      uses: ros-tooling/action-ros-ci@0.0.17
+      uses: ros-tooling/action-ros-ci@0.2.0
       with:
         package-name: |
           joy

--- a/.github/workflows/basic-build-ci.yaml
+++ b/.github/workflows/basic-build-ci.yaml
@@ -13,7 +13,7 @@ jobs:
       image: rostooling/setup-ros-docker:ubuntu-focal-ros-foxy-ros-base-testing-latest
     steps:
     - name: Fix Bugs in ros-tooling/action-ros-ci
-      run: sudo chown -R rosbuild:rosbuild "$HOME" .
+      run: sudo apt update
     - name: Run Tests
       uses: ros-tooling/action-ros-ci@0.2.0
       with:
@@ -21,6 +21,7 @@ jobs:
           joy
           joy_linux
           sdl2_vendor
+          spacenav
           wiimote
           wiimote_msgs
         target-ros2-distro: foxy


### PR DESCRIPTION
I think this should fix the failing action-ros-ci CI tests.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>