### PR TITLE
Override device_id when device_name is provided. (#199)

### DIFF
--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -308,6 +308,7 @@ void Joy::handleJoyDeviceAdded(const SDL_Event & e)
       RCLCPP_WARN(get_logger(), "Failed to get the number of joysticks: %s", SDL_GetError());
       return;
     }
+    bool matching_device_found = false;
     for (int i = 0; i < num_joysticks; ++i) {
       const char * name = SDL_JoystickNameForIndex(i);
       if (name == nullptr) {
@@ -316,9 +317,16 @@ void Joy::handleJoyDeviceAdded(const SDL_Event & e)
       }
       if (std::string(name) == dev_name_) {
         // We found it!
+        matching_device_found = true;
         dev_id_ = i;
         break;
       }
+    }
+    if (!matching_device_found) {
+      RCLCPP_WARN(
+        get_logger(), "Could not get joystick with name %s: %s",
+        dev_name_.c_str(), SDL_GetError());
+      return;
     }
   }
 


### PR DESCRIPTION
Description of issue and solution: https://github.com/ros-drivers/joystick_drivers/issues/199.

Testing:
I ran a bunch of manual tests for this with 1 controller plugged in. The controller is connected to `/dev/input/js0` and its name is 'Core (Plus) Wired Controller'. For each of these test blocks you can see the command I used and also the stdout. See comments above each block for more details.

```
# Node is able to run with no parameters (joystick has device ID 0)
>> ros2 run joy joy_node
[INFO] [1619308203.864072155] [joy_node]: No haptic (rumble) available, skipping initialization
[INFO] [1619308203.864360750] [joy_node]: Opened joystick: Core (Plus) Wired Controller.  deadzone: 0.050000
^C[INFO] [1619308207.401417388] [rclcpp]: signal_handler(signal_value=2)


# Node is able to run with a valid device ID
>> ros2 run joy joy_node --ros-args -p device_id:=0
[INFO] [1619308214.883982110] [joy_node]: No haptic (rumble) available, skipping initialization
[INFO] [1619308214.884268748] [joy_node]: Opened joystick: Core (Plus) Wired Controller.  deadzone: 0.050000
^C[INFO] [1619308217.529583912] [rclcpp]: signal_handler(signal_value=2)


# Node cannot run with an invalid device ID
>> ros2 run joy joy_node --ros-args -p device_id:=1
^C[INFO] [1619308223.904813637] [rclcpp]: signal_handler(signal_value=2)


# Node is able to run with a valid device name
>> ros2 run joy joy_node --ros-args -p device_name:="Core (Plus) Wired Controller"
[INFO] [1619308273.855881093] [joy_node]: No haptic (rumble) available, skipping initialization
[INFO] [1619308273.856185755] [joy_node]: Opened joystick: Core (Plus) Wired Controller.  deadzone: 0.050000
^C[INFO] [1619308275.344509357] [rclcpp]: signal_handler(signal_value=2)


# Node cannot run with an invalid device name
>> ros2 run joy joy_node --ros-args -p device_name:="a fake device"
[WARN] [1619308286.983392624] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
[WARN] [1619308287.279343287] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
[WARN] [1619308287.571295424] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
[WARN] [1619308287.855379969] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
^C[INFO] [1619308288.040089046] [rclcpp]: signal_handler(signal_value=2)
[WARN] [1619308288.131485408] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument


# Node ignores device ID, uses device name and runs correctly
>> ros2 run joy joy_node --ros-args -p device_id:=1 -p device_name:="Core (Plus) Wired Controller"
[INFO] [1619308264.123977929] [joy_node]: No haptic (rumble) available, skipping initialization
[INFO] [1619308264.124257048] [joy_node]: Opened joystick: Core (Plus) Wired Controller.  deadzone: 0.050000
^C[INFO] [1619308267.657040095] [rclcpp]: signal_handler(signal_value=2)


# Node ignores device ID but cannot find device name, fails to run
>> ros2 run joy joy_node --ros-args -p device_id:=1 -p device_name:="a fake device"
[WARN] [1619308241.975517653] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
[WARN] [1619308242.255273797] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
[WARN] [1619308242.551278813] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
[WARN] [1619308242.803296947] [joy_node]: Could not get joystick with name a fake device: Haptic: Unable to get device's features: Invalid argument
^C[INFO] [1619308243.009316567] [rclcpp]: signal_handler(signal_value=2)
```

Setup:
ROS Foxy, Pop!_OS 20.04, wired PowerA Nintendo Switch controller plugged in as /dev/input/js0