### PR TITLE
Install includes to include/ and misc CMake fixes

### DIFF
--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -17,18 +17,18 @@ find_package(sdl2_vendor REQUIRED)
 find_package(sdl2_custom REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-include_directories(include)
 add_library(joy SHARED src/joy.cpp)
-ament_target_dependencies(joy
-  "rclcpp_components"
-  "rclcpp"
-  "sensor_msgs")
-# Need this since sdl2 doesn't properly export its
-# libraries so ament_target_dependencies can find them
-target_link_libraries(joy
+target_include_directories(joy PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(joy PUBLIC
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
   SDL2::SDL2)
+target_link_libraries(joy PRIVATE
+  rclcpp_components::component)
 
-install(TARGETS joy
+install(TARGETS joy EXPORT export_joy
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
@@ -46,12 +46,17 @@ target_link_libraries(joy_enumerate_devices
 install(TARGETS joy_enumerate_devices
   DESTINATION lib/${PROJECT_NAME})
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION include/${PROJECT_NAME}
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 install(DIRECTORY config launch
   DESTINATION share/${PROJECT_NAME})
+
+ament_export_targets(export_joy)
+ament_export_dependencies(
+  "rclcpp"
+  "sensor_msgs"
+  "sdl2_vendor"
+  "sdl2_custom")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/spacenav/CMakeLists.txt
+++ b/spacenav/CMakeLists.txt
@@ -21,17 +21,16 @@ find_package(SPNAV REQUIRED)
 add_library(spacenav
   SHARED
     src/spacenav.cpp)
-target_include_directories(spacenav
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
-ament_target_dependencies(spacenav
-  "geometry_msgs"
-  "rclcpp"
-  "rclcpp_components"
-  "sensor_msgs")
-
-target_link_libraries(spacenav spnav)
+target_include_directories(spacenav PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  ${spnav_INCLUDE_DIR})
+target_link_libraries(spacenav PUBLIC
+  rclcpp::rclcpp
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  spnav)
+target_link_libraries(spacenav PRIVATE
+  rclcpp_components::component)
 
 # Install targets
 install(TARGETS spacenav

--- a/spacenav/CMakeLists.txt
+++ b/spacenav/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+
 project(spacenav)
 
 # Default to C++14
@@ -23,6 +24,7 @@ add_library(spacenav
     src/spacenav.cpp)
 target_include_directories(spacenav PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   ${spnav_INCLUDE_DIR})
 target_link_libraries(spacenav PUBLIC
   rclcpp::rclcpp
@@ -32,21 +34,29 @@ target_link_libraries(spacenav PUBLIC
 target_link_libraries(spacenav PRIVATE
   rclcpp_components::component)
 
-# Install targets
-install(TARGETS spacenav
-  ARCHIVE DESTINATION lib/${PROJECT_NAME}
-  LIBRARY DESTINATION lib/${PROJECT_NAME}
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+install(TARGETS spacenav EXPORT export_spacenav
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
+
+rclcpp_components_register_node(spacenav
+  PLUGIN "spacenav::Spacenav"
+  EXECUTABLE spacenav_node)
+
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}/
 )
 
-rclcpp_components_register_node(spacenav
-  PLUGIN "spacenav::Spacenav"
-  EXECUTABLE spacenav_node)
+ament_export_targets(export_spacenav)
+ament_export_dependencies(
+  "rclcpp"
+  "geometry_msgs"
+  "sensor_msgs"
+  "spnav")
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/wiimote/CMakeLists.txt
+++ b/wiimote/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 include(wiimote-extras.cmake)
 
 find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
@@ -39,7 +40,6 @@ target_link_libraries(wiimote_lib PUBLIC
   ${sensor_msgs_TARGETS}
   ${std_msgs_TARGETS}
   ${std_srvs_TARGETS}
-  ${geometry_msgs_TARGETS}
   ${wiimote_msgs_TARGETS}
   wiimote::bluetooth
   wiimote::cwiid)
@@ -62,8 +62,8 @@ target_include_directories(teleop_wiimote PUBLIC
 target_link_libraries(teleop_wiimote PUBLIC
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
-  ${sensor_msgs_TARGETS}
   ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
   ${wiimote_msgs_TARGETS})
 target_link_libraries(teleop_wiimote PRIVATE
   rclcpp_components::component)
@@ -100,6 +100,13 @@ install(PROGRAMS nodes/feedback_tester.py
 )
 
 ament_export_targets(export_wiimote)
+ament_export_dependencies(
+  "rclcpp"
+  "sensor_msgs"
+  "std_msgs"
+  "std_srvs"
+  "wiimote"
+)
 
 ament_package(
   CONFIG_EXTRAS "wiimote-extras.cmake"

--- a/wiimote/CMakeLists.txt
+++ b/wiimote/CMakeLists.txt
@@ -15,45 +15,36 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_library(BLUETOOTH_LIB bluetooth)
-if(BLUETOOTH_LIB)
-  message(STATUS "Found bluetooth library.")
-else()
-  message(FATAL_ERROR "bluetooth library not found.")
-endif()
-
-find_library(CWIID_LIB cwiid)
-if(CWIID_LIB)
-  message(STATUS "Found cwiid library.")
-else()
-  message(FATAL_ERROR "cwiid library not found.")
-endif()
-
+include(wiimote-extras.cmake)
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_auto REQUIRED)
-
-ament_auto_find_build_dependencies(
-  REQUIRED
-  rclcpp
-  rclcpp_components
-  rclcpp_lifecycle
-  sensor_msgs
-  std_srvs
-  wiimote_msgs
-)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(wiimote_msgs REQUIRED)
 
 ## C++ Wiimote Lib
-set(wiimote_lib_HEADERS
-  include/wiimote/wiimote_controller.hpp
-  include/wiimote/stat_vector_3d.hpp)
-
-set(wiimote_lib_SOURCES
+add_library(wiimote_lib SHARED
   src/wiimote_controller.cpp
   src/stat_vector_3d.cpp)
-
-ament_auto_add_library(wiimote_lib SHARED ${wiimote_lib_HEADERS} ${wiimote_lib_SOURCES})
-target_link_libraries(wiimote_lib bluetooth cwiid)
+target_include_directories(wiimote_lib PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(wiimote_lib PUBLIC
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${wiimote_msgs_TARGETS}
+  wiimote::bluetooth
+  wiimote::cwiid)
+target_link_libraries(wiimote_lib PRIVATE
+  rclcpp_components::component)
 
 rclcpp_components_register_node(
   wiimote_lib
@@ -63,9 +54,19 @@ rclcpp_components_register_node(
 ## End C++ Wiimote Lib
 
 # C++ Teleop for Wiimote Node: Declare cpp executables
-set(teleop_wiimote_HEADERS include/wiimote/teleop_wiimote.hpp)
-set(teleop_wiimote_SOURCES src/teleop_wiimote.cpp)
-ament_auto_add_library(teleop_wiimote SHARED ${teleop_wiimote_HEADERS} ${teleop_wiimote_SOURCES})
+add_library(teleop_wiimote SHARED
+  src/teleop_wiimote.cpp)
+target_include_directories(teleop_wiimote PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(teleop_wiimote PUBLIC
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${wiimote_msgs_TARGETS})
+target_link_libraries(teleop_wiimote PRIVATE
+  rclcpp_components::component)
 
 rclcpp_components_register_node(
   teleop_wiimote
@@ -80,11 +81,11 @@ if(BUILD_TESTING)
 endif()
 
 # Install lib
-install(TARGETS wiimote_lib teleop_wiimote
+install(TARGETS wiimote_lib teleop_wiimote EXPORT export_wiimote
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
-install(DIRECTORY include/ DESTINATION include)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 # Install launch and config files
 install(DIRECTORY launch config
@@ -98,4 +99,8 @@ install(PROGRAMS nodes/feedback_tester.py
   DESTINATION lib/${PROJECT_NAME}
 )
 
-ament_package()
+ament_export_targets(export_wiimote)
+
+ament_package(
+  CONFIG_EXTRAS "wiimote-extras.cmake"
+)

--- a/wiimote/package.xml
+++ b/wiimote/package.xml
@@ -35,10 +35,12 @@
   <build_depend>cwiid-dev</build_depend>
   <exec_depend>cwiid</exec_depend>
 
+  <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>wiimote_msgs</depend>
 

--- a/wiimote/wiimote-extras.cmake
+++ b/wiimote/wiimote-extras.cmake
@@ -1,0 +1,54 @@
+# Copyright 2021 Intel Corporation
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+find_library(BLUETOOTH_LIB bluetooth)
+if(BLUETOOTH_LIB)
+  message(STATUS "Found bluetooth library.")
+else()
+  message(FATAL_ERROR "bluetooth library not found.")
+endif()
+
+find_path(BLUETOOTH_INCLUDE_DIR bluetooth/bluetooth.h)
+if(BLUETOOTH_LIB)
+  message(STATUS "Found bluetooth header.")
+else()
+  message(FATAL_ERROR "bluetooth header not found.")
+endif()
+
+find_library(CWIID_LIB cwiid)
+if(CWIID_LIB)
+  message(STATUS "Found cwiid library.")
+else()
+  message(FATAL_ERROR "cwiid library not found.")
+endif()
+
+find_path(CWIID_INCLUDE_DIR cwiid.h)
+if(CWIID_LIB)
+  message(STATUS "Found cwiid header.")
+else()
+  message(FATAL_ERROR "cwiid header not found.")
+endif()
+
+add_library(wiimote::bluetooth INTERFACE IMPORTED)
+target_link_libraries(wiimote::bluetooth INTERFACE ${BLUETOOTH_LIB})
+target_include_directories(wiimote::bluetooth INTERFACE ${BLUETOOTH_INCLUDE_DIR})
+
+add_library(wiimote::cwiid INTERFACE IMPORTED)
+target_link_libraries(wiimote::cwiid INTERFACE ${CWIID_LIB})
+target_include_directories(wiimote::cwiid INTERFACE ${CWIID_INCLUDE_DIR})
+
+unset(BLUETOOTH_LIB)
+unset(BLUETOOTH_INCLUDE_DIR)
+unset(CWIID_LIB)
+unset(CWIID_INCLUDE_DIR)


### PR DESCRIPTION
Part of ros2/ros2#1150

This installs includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages in desktop.

Part of ament/ament_cmake#292

This replaces `ament_target_dependencies()` calls with `target_link_libraries()`.

I also made changes to use modern CMake targets, notably by creating IMPORTED targets `wiimote::bluetooth` and `wiimote::cwid` to make the `wiimote::wiimote_lib` target exportable.

Requires ros2/rclcpp#1855 for the `rclcpp_components::component` target.
