### PR TITLE
Installing libspacenav.so to lib/ for spacenav_node execution via ros…

### DIFF
--- a/spacenav/CMakeLists.txt
+++ b/spacenav/CMakeLists.txt
@@ -49,6 +49,10 @@ rclcpp_components_register_node(spacenav
   PLUGIN "spacenav::Spacenav"
   EXECUTABLE spacenav_node)
 
+install(TARGETS spacenav
+  DESTINATION lib
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   set(ament_cmake_copyright_FOUND TRUE)

--- a/spacenav/README.md
+++ b/spacenav/README.md
@@ -39,6 +39,6 @@
 
 Running the node is straightforward
 ```
-$ ros2 run spacenav spacenav
+$ ros2 run spacenav spacenav_node
 ```
 The node is now publishing to the topics listed above.


### PR DESCRIPTION
This is basically the fix proposed by @adrianramospeon in https://github.com/ros-drivers/joystick_drivers/issues/221#issuecomment-942475652

See #221 for more details.