### PR TITLE
Spacenav: Changed name of executable in launch files to match installed node

### DIFF
--- a/spacenav/CMakeLists.txt
+++ b/spacenav/CMakeLists.txt
@@ -66,10 +66,6 @@ ament_export_dependencies(
   ${THIS_PACKAGE_INCLUDE_DEPENDS}
 )
 
-install(TARGETS spacenav
-  DESTINATION lib
-)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   set(ament_cmake_copyright_FOUND TRUE)

--- a/spacenav/launch/classic-launch.py
+++ b/spacenav/launch/classic-launch.py
@@ -30,9 +30,15 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        Node(package='spacenav', executable='spacenav',
-             name='spacenav', namespace='', output='screen',
-             parameters=[{'zero_when_static': True,
-                          'static_count_threshold': 30}]),
-    ])
+    return LaunchDescription(
+        [
+            Node(
+                package='spacenav',
+                executable='spacenav_node',
+                name='spacenav',
+                namespace='',
+                output='screen',
+                parameters=[{'zero_when_static': True, 'static_count_threshold': 30}],
+            ),
+        ]
+    )

--- a/spacenav/launch/no_deadband-launch.py
+++ b/spacenav/launch/no_deadband-launch.py
@@ -30,10 +30,21 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        Node(package='spacenav', executable='spacenav',
-             name='spacenav', namespace='', output='screen',
-             parameters=[{'zero_when_static': False,
-                          'static_trans_deadband': 0.0,
-                          'static_rot_deadband': 0.0}]),
-    ])
+    return LaunchDescription(
+        [
+            Node(
+                package='spacenav',
+                executable='spacenav_node',
+                name='spacenav',
+                namespace='',
+                output='screen',
+                parameters=[
+                    {
+                        'zero_when_static': False,
+                        'static_trans_deadband': 0.0,
+                        'static_rot_deadband': 0.0,
+                    }
+                ],
+            ),
+        ]
+    )

--- a/spacenav/launch/static_deadband-launch.py
+++ b/spacenav/launch/static_deadband-launch.py
@@ -30,11 +30,22 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-    return LaunchDescription([
-        Node(package='spacenav', executable='spacenav',
-             name='spacenav', namespace='', output='screen',
-             parameters=[{'zero_when_static': False,
-                          'static_count_threshold': 30,
-                          'static_trans_deadband': 40.0,
-                          'static_rot_deadband': 40.0}]),
-    ])
+    return LaunchDescription(
+        [
+            Node(
+                package='spacenav',
+                executable='spacenav_node',
+                name='spacenav',
+                namespace='',
+                output='screen',
+                parameters=[
+                    {
+                        'zero_when_static': False,
+                        'static_count_threshold': 30,
+                        'static_trans_deadband': 40.0,
+                        'static_rot_deadband': 40.0,
+                    }
+                ],
+            ),
+        ]
+    )


### PR DESCRIPTION
The installed executable was named `spacenav_node` in [CMakeLists.txt:50](https://github.com/ros-drivers/joystick_drivers/blob/foxy-devel/spacenav/CMakeLists.txt#L50), but the launch files tried to call `executable='spacenav'`.

I've fixed the spelling in the three launch files and tested them on foxy.