### PR TITLE
Remove trailing whitespace from .msg files.

### DIFF
--- a/wiimote_msgs/msg/IrSourceInfo.msg
+++ b/wiimote_msgs/msg/IrSourceInfo.msg
@@ -1,21 +1,21 @@
 # Sensor data pertaining to the Wiimote infrared camera.
-# This message contains data for one of the four infrared 
+# This message contains data for one of the four infrared
 # light sources that the camera detects.
 #
-# Each light is specified with a 2D position and 
+# Each light is specified with a 2D position and
 # a 'source magnitude' (ir_size). If the x dimension
-# is set to INVALID_FLOAT, then no light was detected for 
+# is set to INVALID_FLOAT, then no light was detected for
 # the respective light. The Wiimote handles up to
 # four light sources, and the wiimote_controller software
 # is written to that limit as well.
 #
-# I am unsure what the 'ir_size' values represent. 
+# I am unsure what the 'ir_size' values represent.
 # They are described as 'source magnitude' in some places. I
-# *assume* this is signal amplitude, but it's unclear. 
-# Note that current lowest level cwiid driver does not 
-# seem to pass the ir_size value to the cwiid Wiimote.c. 
+# *assume* this is signal amplitude, but it's unclear.
+# Note that current lowest level cwiid driver does not
+# seem to pass the ir_size value to the cwiid Wiimote.c.
 # For now this size will therefore be set INVALID
 
-float64 x 
-float64 y 
+float64 x
+float64 y
 int64 ir_size

--- a/wiimote_msgs/msg/TimedSwitch.msg
+++ b/wiimote_msgs/msg/TimedSwitch.msg
@@ -16,7 +16,7 @@
 #          n>=0: run the pattern that is defined in pulse_pattern
 #                n times.
 #          n==FOREVER: run the pattern that is defined in pulse_pattern
-#                       until a new TimedSwitch message is sent.              
+#                       until a new TimedSwitch message is sent.
 #
 #     o pulse_pattern:
 #          A series of time durations in fractions of a second. The
@@ -24,8 +24,8 @@
 #          The second number is the duration for which the switch
 #          is off. The third is an 'on' period again, etc.
 #          A pattern is terminated with the end of the array.
-#           
-#          Example: [1,1] specifies an on-off sequence of 1 second.               
+#
+#          Example: [1,1] specifies an on-off sequence of 1 second.
 
 int8 ON        =  1
 int8 OFF       =  0


### PR DESCRIPTION
This makes it so that newer versions of uncrustify won't complain.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>