### PR TITLE
[ROS-O] do not force old c++11 standard

### DIFF
--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(joy)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Load catkin and all dependencies required for this package
 set(CATKIN_DEPS roscpp diagnostic_updater sensor_msgs roslint)
 find_package(catkin REQUIRED ${CATKIN_DEPS})

--- a/spacenav_node/CMakeLists.txt
+++ b/spacenav_node/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(spacenav_node)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Load catkin and all dependencies required for this package
 set(CATKIN_DEPS roscpp geometry_msgs sensor_msgs roslint)
 find_package(catkin REQUIRED ${CATKIN_DEPS})


### PR DESCRIPTION
log4cxx requires c++17 these days and explicitly setting an old standard breaks it.