### PR TITLE
add ps3joy remap

### DIFF
--- a/joy/config/ps3joy.yaml
+++ b/joy/config/ps3joy.yaml
@@ -1,0 +1,47 @@
+mappings:
+  axes:
+    - axes[0]
+    - axes[1]
+    - axes[3]
+    - axes[4]
+    - 0
+    - 0
+    - 0
+    - 0
+    - -1.0 * buttons[13]
+    - -1.0 * buttons[16]
+    - -1.0 * buttons[14]
+    - -1.0 * buttons[15]
+    - 0.5 * ( axes[2] - 1 )
+    - 0.5 * ( axes[5] - 1 )
+    - -1.0 * buttons[4]
+    - -1.0 * buttons[5]
+    - -1.0 * buttons[2]
+    - -1.0 * buttons[1]
+    - -1.0 * buttons[0]
+    - -1.0 * buttons[3]
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+    - 0
+  buttons:
+    - buttons[8]
+    - buttons[11]
+    - buttons[12]
+    - buttons[9]
+    - buttons[13]
+    - buttons[16]
+    - buttons[14]
+    - buttons[15]
+    - buttons[6]
+    - buttons[7]
+    - buttons[4]
+    - buttons[5]
+    - buttons[2]
+    - buttons[1]
+    - buttons[0]
+    - buttons[3]
+    - buttons[10]

--- a/joy/launch/ps3joy.launch
+++ b/joy/launch/ps3joy.launch
@@ -1,0 +1,12 @@
+<launch>
+  <!-- assumes ds4drv is running -->
+  <node name="joy_node" pkg="joy" type="joy_node">
+    <remap from="joy" to="joy_orig"/>
+  </node>
+  <!-- remap joy to emulate ps3joy mappings -->
+  <node name="joy_remap" pkg="joy" type="joy_remap.py">
+    <remap from="joy_in" to="joy_orig"/>
+    <remap from="joy_out" to="joy"/>
+    <rosparam command="load" file="$(find joy)/config/ps3joy.yaml"/>
+  </node>
+</launch>


### PR DESCRIPTION
I added a remapping yaml file and a sample launch file for ps3joy controller. I checked this works correctly with melodic 1.14.13.