### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/wiimote/package.xml
+++ b/wiimote/package.xml
@@ -24,6 +24,8 @@
   <author email="mark.d.horn@intel.com">Mark Horn</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>roslint</build_depend>

--- a/wiimote/package.xml
+++ b/wiimote/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>wiimote</name>
   <version>1.15.0</version>
   <license>GPL</license>

--- a/wiimote/setup.py
+++ b/wiimote/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.
