### PR TITLE
Revert "Fix dependency issues."

### DIFF
--- a/joy/CMakeLists.txt
+++ b/joy/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sdl2_vendor REQUIRED)
@@ -21,12 +21,12 @@ add_library(joy SHARED src/joy.cpp)
 target_include_directories(joy PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(joy
-  rclcpp
-  rclcpp_components
-  sensor_msgs)
-target_link_libraries(joy
+target_link_libraries(joy PUBLIC
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
   SDL2::SDL2)
+target_link_libraries(joy PRIVATE
+  rclcpp_components::component)
 
 install(TARGETS joy EXPORT export_joy
   LIBRARY DESTINATION lib

--- a/joy/package.xml
+++ b/joy/package.xml
@@ -22,7 +22,7 @@
   <author>Blaise Gassend</author>
   <author>Jonathan Bohren</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/wiimote/CMakeLists.txt
+++ b/wiimote/CMakeLists.txt
@@ -34,17 +34,17 @@ add_library(wiimote_lib SHARED
 target_include_directories(wiimote_lib PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(wiimote_lib
-  rclcpp
-  rclcpp_components
-  rclcpp_lifecycle
-  sensor_msgs
-  std_msgs
-  std_srvs
-  wiimote_msgs)
-target_link_libraries(wiimote_lib
+target_link_libraries(wiimote_lib PUBLIC
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
+  ${wiimote_msgs_TARGETS}
   wiimote::bluetooth
   wiimote::cwiid)
+target_link_libraries(wiimote_lib PRIVATE
+  rclcpp_components::component)
 
 rclcpp_components_register_node(
   wiimote_lib
@@ -59,13 +59,14 @@ add_library(teleop_wiimote SHARED
 target_include_directories(teleop_wiimote PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(teleop_wiimote
-  rclcpp
-  rclcpp_components
-  rclcpp_lifecycle
-  geometry_msgs
-  sensor_msgs
-  wiimote_msgs)
+target_link_libraries(teleop_wiimote PUBLIC
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${wiimote_msgs_TARGETS})
+target_link_libraries(teleop_wiimote PRIVATE
+  rclcpp_components::component)
 
 rclcpp_components_register_node(
   teleop_wiimote


### PR DESCRIPTION
This reverts commit 11a70ca6c5bdcebec3bfc6d861cb8d715b456581.

We are trying to move away from `ament_target_dependencies`, so the CMake logic as it was originally written should stay.  @JWhitleyWork did you have a particular problem that caused you to push this commit?