### PR TITLE
Initializing the axis values with 0

### DIFF
--- a/joy/include/joy/joy.hpp
+++ b/joy/include/joy/joy.hpp
@@ -78,6 +78,7 @@ private:
   int autorepeat_interval_ms_{0};
   bool sticky_buttons_{false};
   bool publish_soon_{false};
+  bool init_{true};
   rclcpp::Time publish_soon_time_;
   int coalesce_interval_ms_{0};
   std::string dev_name_;

--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -384,14 +384,16 @@ void Joy::handleJoyDeviceAdded(const SDL_Event & e)
     if (init_) {
       joy_msg_.axes.at(i) = 0;
     } else {
-        if (SDL_JoystickGetAxisInitialState(joystick_, i, &state)) {
+      if (SDL_JoystickGetAxisInitialState(joystick_, i, &state)) {
         joy_msg_.axes.at(i) = convertRawAxisValueToROS(state);
-      }  
+      }
     }
   }
 
   if (init_) {
     init_ = false;
+  } else {
+    init_ = true;
   }
 
   haptic_ = SDL_HapticOpenFromJoystick(joystick_);
@@ -416,6 +418,7 @@ void Joy::handleJoyDeviceRemoved(const SDL_Event & e)
     return;
   }
 
+  init_ = true;  // resetting init to true, in case JS is reconnected in the same instance
   joy_msg_.buttons.resize(0);
   joy_msg_.axes.resize(0);
   if (haptic_ != nullptr) {

--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -381,9 +381,17 @@ void Joy::handleJoyDeviceAdded(const SDL_Event & e)
   // Get the initial state for each of the axes
   for (int i = 0; i < num_axes; ++i) {
     int16_t state;
-    if (SDL_JoystickGetAxisInitialState(joystick_, i, &state)) {
-      joy_msg_.axes.at(i) = convertRawAxisValueToROS(state);
+    if (init_) {
+      joy_msg_.axes.at(i) = 0;
+    } else {
+        if (SDL_JoystickGetAxisInitialState(joystick_, i, &state)) {
+        joy_msg_.axes.at(i) = convertRawAxisValueToROS(state);
+      }  
     }
+  }
+
+  if (init_) {
+    init_ = false;
   }
 
   haptic_ = SDL_HapticOpenFromJoystick(joystick_);


### PR DESCRIPTION
As reported in the issue #263, SDL sets the max negative value to the axis during initialization of joystick. 

Since it's event based, we had to trigger the gears in order for the axis values to be set to 0, before pressing the deadman button. With this update, the axis values will be initialized with 0, meaning that, there is no requirement of manual calibration. 

Of course, when the deadman button or any of the button is pressed for the first time, all the axes values are set to 0 by the SDL. Since it's event based mechanism, those zeros on the axes aren't read, but rather the joy node takes the initial state defined by the SDL. With this PR, the issue is taken care of. 

