### PR TITLE
Update ROS2 Workflows and Badges

### DIFF
--- a/.github/workflows/humble-build-ci.yaml
+++ b/.github/workflows/humble-build-ci.yaml
@@ -1,4 +1,4 @@
-name: Basic Build Workflow
+name: Humble Build
 
 on:
   - pull_request
@@ -29,7 +29,7 @@ jobs:
           wiimote_msgs
         target-ros2-distro: humble
     - name: Upload logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: colcon-logs
         path: ${{ steps.humble_action_ros_ci_step.outputs.ros-workspace-directory-name }}/log

--- a/.github/workflows/jazzy-build-ci.yaml
+++ b/.github/workflows/jazzy-build-ci.yaml
@@ -1,24 +1,24 @@
-name: Basic Build Workflow
+name: Jazzy Build
 
 on:
   - pull_request
   - push
 
 jobs:
-  build-iron:
-    runs-on: ubuntu-22.04
+  build-rolling:
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-desktop-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-jazzy-desktop-latest
     steps:
     - name: Build Environment
       uses: ros-tooling/setup-ros@v0.7
       with:
-        required-ros-distributions: iron
+        required-ros-distributions: jazzy
     - name: Run Tests
       uses: ros-tooling/action-ros-ci@v0.3
-      id: iron_action_ros_ci_step
+      id: jazzy_action_ros_ci_step
       with:
         package-name: |
           joy
@@ -27,10 +27,10 @@ jobs:
           spacenav
           wiimote
           wiimote_msgs
-        target-ros2-distro: iron
+        target-ros2-distro: jazzy
     - name: Upload logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: colcon-logs
-        path: ${{ steps.iron_action_ros_ci_step.outputs.ros-workspace-directory-name }}/log
+        path: ${{ steps.jazzy_action_ros_ci_step.outputs.ros-workspace-directory-name }}/log
       if: always()

--- a/.github/workflows/rolling-build-ci.yaml
+++ b/.github/workflows/rolling-build-ci.yaml
@@ -1,4 +1,4 @@
-name: Basic Build Workflow
+name: Rolling Build
 
 on:
   - pull_request
@@ -6,11 +6,11 @@ on:
 
 jobs:
   build-rolling:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-desktop-latest
+      image: rostooling/setup-ros-docker:ubuntu-noble-ros-rolling-desktop-latest
     steps:
     - name: Build Environment
       uses: ros-tooling/setup-ros@v0.7
@@ -29,7 +29,7 @@ jobs:
           wiimote_msgs
         target-ros2-distro: rolling
     - name: Upload logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: colcon-logs
         path: ${{ steps.rolling_action_ros_ci_step.outputs.ros-workspace-directory-name }}/log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ROS Joystick Drivers Stack #
 
-[![](https://github.com/ros-drivers/joystick_drivers/workflows/Basic%20Build%20Workflow/badge.svg?branch=ros2)](https://github.com/ros-drivers/joystick_drivers/actions)
+[![Humble Build](https://github.com/ros-drivers/joystick_drivers/workflows/Humble%20Build/badge.svg?branch=ros2)](https://github.com/ros-drivers/joystick_drivers/actions)
+[![Jazzy Build](https://github.com/ros-drivers/joystick_drivers/workflows/Jazzy%20Build/badge.svg?branch=ros2)](https://github.com/ros-drivers/joystick_drivers/actions)
+[![Rolling Build](https://github.com/ros-drivers/joystick_drivers/workflows/Rolling%20Build/badge.svg?branch=ros2)](https://github.com/ros-drivers/joystick_drivers/actions)
 
 A simple set of nodes for supporting various types of joystick inputs and producing ROS messages from the underlying OS messages.
 


### PR DESCRIPTION
- Remove Iron workflow because it's EOL
- Add Jazzy workflow
- Update Rolling workflow
- Add badges to README for each workflow
- Update `upload-artifact` because old version is deprecated