### PR TITLE
joy_linux: clean shutdown when terminated by signal handler

### DIFF
--- a/joy_linux/src/joy_linux_node.cpp
+++ b/joy_linux/src/joy_linux_node.cpp
@@ -532,8 +532,9 @@ public:
 
       close(ff_fd_);
       close(joy_fd);
-      rclcpp::spin_some(node_);
+
       if (rclcpp::ok()) {
+        rclcpp::spin_some(node_);
         RCLCPP_ERROR(
           node_->get_logger(), "Connection to joystick device lost unexpectedly. Will reopen.");
       }


### PR DESCRIPTION
The joy_linux node does not shut down gracefully if terminated by a signal, for example CTRL+C/SIGINT. This happens because the context is invalidated by the signal handler, and the node main function attempts to call spin_node directly after exiting the innermost while loop. Example of unclean exit:
```
[INFO] [1733839990.289835426] [joy_node]: Opened joystick: /dev/input/js0. deadzone_: 0.050000.
^C[INFO] [1733839993.157844512] [rclcpp]: signal_handler(signum=2)
terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
  what():  failed to create guard condition: the given context is not valid, either rcl_init() was not called or rcl_shutdown() was called., at /tmp/makepkg/ros2-jazzy-base/src/ros2/src/ros2/rcl/rcl/src/rcl/guard_condition.c:67
Aborted (core dumped)
```

This PR moves the offending call to spin_some inside the rclcpp::ok() check to at least catch most of these cases. This results in a clean shutdown without the exception:
```
[INFO] [1733841481.096457734] [joy_node]: Opened joystick: /dev/input/js0. deadzone_: 0.050000.
^C[INFO] [1733841482.468186414] [rclcpp]: signal_handler(signum=2)
[INFO] [1733841482.573050534] [joy_node]: joy_node shut down.
```