### PR TITLE
fix coalesce_interval_ms not working correctly

### DIFF
--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -450,16 +450,8 @@ void Joy::eventThread()
       } else {
         RCLCPP_INFO(get_logger(), "Unknown event type %d", e.type);
       }
-    }
-
-    if (!should_publish) {
-      // So far, nothing has indicated that we should publish.  However we need to
-      // do additional checking since there are several possible reasons:
-      // 1.  SDL_WaitEventTimeout failed
-      // 2.  SDL_WaitEventTimeout timed out
-      // 3.  SDL_WaitEventTimeout succeeded, but the event that happened didn't cause
-      //     a publish to happen.
-      //
+    } else {
+      // We didn't succeed, either because of a failure or because of a timeout.
       // If we are autorepeating and enough time has passed, set should_publish.
       rclcpp::Time now = this->now();
       rclcpp::Duration diff_since_last_publish = now - last_publish;


### PR DESCRIPTION
https://github.com/ros-drivers/joystick_drivers/issues/284

The coalesce_interval_ms parameter doesn't get used properly. Spamming axis events (ex: spinning joysticks) causes rates to get very high.

`should_publish` is being incorrectly overwritten to true in the event loop function.

The PR makes the event loop logic the same as `game_controller_node` which did not have this issue from my testing.