### PR TITLE
Add support to game_controller_node for sending separate intensities to left and right rumble motors.

### DIFF
--- a/joy/include/joy/game_controller.hpp
+++ b/joy/include/joy/game_controller.hpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>
@@ -75,6 +76,10 @@ private:
   double scale_{0.0};
   double autorepeat_rate_{0.0};
   int autorepeat_interval_ms_{0};
+  std::pair<builtin_interfaces::msg::Time, uint16_t> rumble_intensity_left_stamped_{
+    builtin_interfaces::msg::Time(), 0};
+  std::pair<builtin_interfaces::msg::Time, uint16_t> rumble_intensity_right_stamped_{
+    builtin_interfaces::msg::Time(), 0};
   bool sticky_buttons_{false};
   bool publish_soon_{false};
   rclcpp::Time publish_soon_time_;

--- a/joy/src/game_controller.cpp
+++ b/joy/src/game_controller.cpp
@@ -131,14 +131,10 @@ GameController::~GameController()
 
 void GameController::feedbackCb(const std::shared_ptr<sensor_msgs::msg::JoyFeedback> msg)
 {
+  uint32_t duration_ms = 1000;
+
   if (msg->type != sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE) {
     // We only support rumble
-    return;
-  }
-
-  if (msg->id != 0) {
-    // There can be only one (rumble)
-    // TODO(Rod Taylor): Support high and low frequency rumble channels.
     return;
   }
 
@@ -147,10 +143,38 @@ void GameController::feedbackCb(const std::shared_ptr<sensor_msgs::msg::JoyFeedb
     return;
   }
 
+  uint16_t intensity = static_cast<uint16_t>(msg->intensity * 0xFFFF);
+  rclcpp::Time now = this->now();
+
+  // 0: Both left motor (low frequency) and right motor (high frequency) rumble
+  // 1: Left rumble
+  // 2: Right rumble
+  if (msg->id == 0) {
+    rumble_intensity_left_stamped_ = {now, intensity};
+    rumble_intensity_right_stamped_ = {now, intensity};
+  } else if (msg->id == 1) {
+    rumble_intensity_left_stamped_ = {now, intensity};
+    if ((now - rumble_intensity_right_stamped_.first) >=
+      rclcpp::Duration::from_seconds(duration_ms / 1000.0))
+    {
+      rumble_intensity_right_stamped_ = {now, 0};
+    }
+  } else if (msg->id == 2) {
+    rumble_intensity_right_stamped_ = {now, intensity};
+    if ((now - rumble_intensity_left_stamped_.first) >=
+      rclcpp::Duration::from_seconds(duration_ms / 1000.0))
+    {
+      rumble_intensity_left_stamped_ = {now, 0};
+    }
+  } else {
+    return;
+  }
+
   if (game_controller_ != nullptr) {
     // We purposely ignore the return value; if it fails, what can we do?
-    uint16_t intensity = static_cast<uint16_t>(msg->intensity * 0xFFFF);
-    SDL_GameControllerRumble(game_controller_, intensity, intensity, 1000);
+    SDL_GameControllerRumble(
+      game_controller_, rumble_intensity_left_stamped_.second,
+      rumble_intensity_right_stamped_.second, duration_ms);
   }
 }
 


### PR DESCRIPTION
#298 

Add support to `game_controller_node` for sending rumble effects to left and right rumble motors individually.

`id` field in `JoyFeedback` message now specifies which motor to rumble:
- `id: 0` both motors (matches current behaviour)
- `id: 1` left (LF) motor
- `id: 2` right (HF) motor

`intensity_left_stamped_` and `intensity_right_stamped_` store the value and timestamp of the most recent rumble command on that motor. Calls to `SDL_GameControllerRumble()` set rumble intensity values for both motors. Now, if a callback is triggered for a left-only or right-only rumble message, the node checks whether the other motor should still be rumbling. If so, it re-uses its previous intensity value, and otherwise sets its intensity to `0`.