### PR TITLE
Change deprecated std::bind1st usage to std::bind

### DIFF
--- a/wiimote/src/stat_vector_3d.cpp
+++ b/wiimote/src/stat_vector_3d.cpp
@@ -88,7 +88,8 @@ TVectorDouble StatVector3d::getMeanScaled(double scale)
   TVectorDouble mean = getMeanRaw();
 
   std::transform(
-    mean.begin(), mean.end(), mean.begin(), std::bind1st(std::multiplies<double>(), scale));
+    mean.begin(), mean.end(), mean.begin(),
+    std::bind(std::multiplies<double>(), scale, std::placeholders::_1));
 
   return mean;
 }
@@ -136,7 +137,7 @@ TVectorDouble StatVector3d::getVarianceScaled(double scale)
 
   std::transform(
     variance.begin(), variance.end(), variance.begin(),
-    std::bind1st(std::multiplies<double>(), scale));
+    std::bind(std::multiplies<double>(), scale, std::placeholders::_1));
 
   return variance;
 }
@@ -159,7 +160,8 @@ TVectorDouble StatVector3d::getStandardDeviationScaled(double scale)
   TVectorDouble stddev = getStandardDeviationRaw();
 
   std::transform(
-    stddev.begin(), stddev.end(), stddev.begin(), std::bind1st(std::multiplies<double>(), scale));
+    stddev.begin(), stddev.end(), stddev.begin(),
+    std::bind(std::multiplies<double>(), scale, std::placeholders::_1));
 
   return stddev;
 }


### PR DESCRIPTION
Change deprecated usage in `wiimote_node`'s `stat_vector_3d.cpp` to resolve warnings which are causing PR checks to fail.