### PR TITLE
[WIP] SDL2 on macOS detects joysticks only with SDL2_INIT_VIDEO

### DIFF
--- a/joy/src/game_controller.cpp
+++ b/joy/src/game_controller.cpp
@@ -105,24 +105,23 @@ GameController::GameController(const rclcpp::NodeOptions & options)
 
   future_ = exit_signal_.get_future();
 
-  // In theory we could do this with just a timer, which would simplify the code
-  // a bit.  But then we couldn't react to "immediate" events, so we stick with
-  // the thread.
-  event_thread_ = std::thread(&GameController::eventThread, this);
-
   joy_msg_.buttons.resize(SDL_CONTROLLER_BUTTON_MAX);
 
   joy_msg_.axes.resize(SDL_CONTROLLER_AXIS_MAX);
 
-  if (SDL_Init(SDL_INIT_GAMECONTROLLER) < 0) {
+  if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) < 0) {
     throw std::runtime_error("SDL could not be initialized: " + std::string(SDL_GetError()));
   }
+
+  // In theory we could do this with just a timer, which would simplify the code
+  // a bit.  But then we couldn't react to "immediate" events, so we stick with
+  // the thread.
+  this->eventThread();
 }
 
 GameController::~GameController()
 {
   exit_signal_.set_value();
-  event_thread_.join();
   if (game_controller_ != nullptr) {
     SDL_GameControllerClose(game_controller_);
   }

--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -105,13 +105,13 @@ Joy::Joy(const rclcpp::NodeOptions & options)
 
   future_ = exit_signal_.get_future();
 
-  if (SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC) < 0) {
+  if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC) < 0) {
     throw std::runtime_error("SDL could not be initialized: " + std::string(SDL_GetError()));
   }
   // In theory we could do this with just a timer, which would simplify the code
   // a bit.  But then we couldn't react to "immediate" events, so we stick with
   // the thread.
-  event_thread_ = std::thread(&Joy::eventThread, this);
+  this->eventThread();
 }
 
 Joy::~Joy()

--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -117,7 +117,6 @@ Joy::Joy(const rclcpp::NodeOptions & options)
 Joy::~Joy()
 {
   exit_signal_.set_value();
-  event_thread_.join();
   if (haptic_ != nullptr) {
     SDL_HapticClose(haptic_);
   }

--- a/joy/src/joy_enumerate_devices.cpp
+++ b/joy/src/joy_enumerate_devices.cpp
@@ -38,43 +38,49 @@
 int main()
 {
   // SDL_INIT_GAMECONTROLLER implies SDL_INIT_JOYSTICK
-  if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) < 0) {
+  if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC ) < 0) {
     fprintf(stderr, "SDL could not be initialized: %s\n", SDL_GetError());
     return 1;
   }
 
-  fprintf(
-    stdout,
-    "ID : GUID                             : GamePad : Mapped : Joystick Device Name\n");
-  fprintf(
-    stdout,
-    "-------------------------------------------------------------------------------\n");
-  for (int i = 0; i < SDL_NumJoysticks(); ++i) {
-    SDL_JoystickGUID joystick_guid;
-    const char * joystick_name = "Unknown";
-    const char * has_mapping_string = "false";
-    const char * is_gamepad = "false";
-
-    if (SDL_IsGameController(i)) {
-      SDL_GameController * controller = SDL_GameControllerOpen(i);
-      joystick_guid = SDL_JoystickGetGUID(SDL_GameControllerGetJoystick(controller));
-      joystick_name = SDL_GameControllerName(controller);
-      if (nullptr != SDL_GameControllerMapping(controller)) {
-        has_mapping_string = "true";
-      }
-      is_gamepad = "true";
-
-    } else {
-      joystick_name = SDL_JoystickNameForIndex(i);
-      joystick_guid = SDL_JoystickGetDeviceGUID(i);
-    }
-
-    char guid_string[33];
-    SDL_JoystickGetGUIDString(joystick_guid, guid_string, sizeof(guid_string));
+  while (true) {
+    SDL_PumpEvents();
 
     fprintf(
-      stdout, "%2d : %32s : %7s : %6s : %s\n", i, guid_string, is_gamepad, has_mapping_string,
-      joystick_name);
+      stdout,
+      "ID : GUID                             : GamePad : Mapped : Joystick Device Name\n");
+    fprintf(
+      stdout,
+      "-------------------------------------------------------------------------------\n");
+    for (int i = 0; i < SDL_NumJoysticks(); ++i) {
+      SDL_JoystickGUID joystick_guid;
+      const char * joystick_name = "Unknown";
+      const char * has_mapping_string = "false";
+      const char * is_gamepad = "false";
+
+      if (SDL_IsGameController(i)) {
+        SDL_GameController * controller = SDL_GameControllerOpen(i);
+        joystick_guid = SDL_JoystickGetGUID(SDL_GameControllerGetJoystick(controller));
+        joystick_name = SDL_GameControllerName(controller);
+        if (nullptr != SDL_GameControllerMapping(controller)) {
+          has_mapping_string = "true";
+        }
+        is_gamepad = "true";
+
+      } else {
+        joystick_name = SDL_JoystickNameForIndex(i);
+        joystick_guid = SDL_JoystickGetDeviceGUID(i);
+      }
+
+      char guid_string[33];
+      SDL_JoystickGetGUIDString(joystick_guid, guid_string, sizeof(guid_string));
+
+      fprintf(
+        stdout, "%2d : %32s : %7s : %6s : %s\n", i, guid_string, is_gamepad, has_mapping_string,
+        joystick_name);
+    }
+
+    SDL_Delay(1000);
   }
 
   SDL_Quit();


### PR DESCRIPTION
SDL2 on macOS seems to have issues detecting joysticks that are already connected at startup (I started a discussion here: https://github.com/libsdl-org/SDL/issues/12886).

I'm opening a PR to share this workaround that seems to make everything work correctly, but it's not a proper fix right now. I'm sure initialising SDL2_INIT_VIDEO is not very desirable, especially not on other platforms, as it prevents the joy node from running headless.

Was this a known issue?