### PR TITLE
surpress warnings for known unused event types

### DIFF
--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -50,8 +50,7 @@ namespace joy
 static const std::unordered_set<Uint32> ignored_sdl_events = {
   SDL_CONTROLLERTOUCHPADDOWN,
   SDL_CONTROLLERTOUCHPADMOTION,
-  SDL_CONTROLLERTOUCHPADUP,
-  SDL_JOYBATTERYUPDATED
+  SDL_CONTROLLERTOUCHPADUP
 };
 
 Joy::Joy(const rclcpp::NodeOptions & options)

--- a/joy/src/joy.cpp
+++ b/joy/src/joy.cpp
@@ -47,6 +47,12 @@
 
 namespace joy
 {
+static const std::unordered_set<Uint32> ignored_sdl_events = {
+  SDL_CONTROLLERTOUCHPADDOWN,
+  SDL_CONTROLLERTOUCHPADMOTION,
+  SDL_CONTROLLERTOUCHPADUP,
+  SDL_JOYBATTERYUPDATED
+};
 
 Joy::Joy(const rclcpp::NodeOptions & options)
 : rclcpp::Node("joy_node", options)
@@ -435,7 +441,9 @@ void Joy::eventThread()
     int success = SDL_WaitEventTimeout(&e, wait_time_ms);
     if (success == 1) {
       // Succeeded getting an event
-      if (e.type == SDL_JOYAXISMOTION) {
+      if (ignored_sdl_events.count(e.type) == 1) {
+        // ignore events which explicitly have no purpose to reduce log verbosity
+      } else if (e.type == SDL_JOYAXISMOTION) {
         should_publish = handleJoyAxis(e);
       } else if (e.type == SDL_JOYBUTTONDOWN) {
         should_publish = handleJoyButtonDown(e);


### PR DESCRIPTION
When using newer gamepads such as the Dualshock 5 it's pretty common to see messages along the lines of `Unknown event type 1623`. These messages can be useful for maintainers of the joystick_drivers package but the average joe doesn't really care.

In some scenarios, such as with the aforementioned Dualshock 5, these messages will be printed in a torrential flood at whatever rate the joy_node is publishing at. It is quite frustrating to suddenly need to sift through hundreds of lines of repeated log messages simply because I accidentally bumped my controllers touch pad.

This pull request proposes adding a list of SDL events which are explicitly known to pose no function within the joy_node. This way any actually anomalous unknown events can still be logged without the worry of drowning in useless log messages