### PR TITLE
fix node args used to launch joy nodes via launch file

### DIFF
--- a/joy/config/joy-params.yaml
+++ b/joy/config/joy-params.yaml
@@ -1,7 +1,7 @@
 joy_node:
     ros__parameters:
         device_id: 0
-        device_name: "''"
+        device_name: ""
         deadzone: 0.5
         autorepeat_rate: 20.0
         sticky_buttons: false

--- a/joy/launch/joy-composed-launch.py
+++ b/joy/launch/joy-composed-launch.py
@@ -47,15 +47,15 @@ def generate_launch_description():
         params = yaml.safe_load(f)['joy_node']['ros__parameters']
 
     container = ComposableNodeContainer(
-            node_name='joy_container',
-            node_namespace='',
+            name='joy_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='joy',
-                    node_plugin='joy::Joy',
-                    node_name='joy_node',
+                    plugin='joy::Joy',
+                    name='joy_node',
                     parameters=[params])
             ],
             output='both',

--- a/joy/launch/joy-launch.py
+++ b/joy/launch/joy-launch.py
@@ -40,7 +40,7 @@ def generate_launch_description():
         'config')
     params = os.path.join(config_directory, 'joy-params.yaml')
     joy_node = launch_ros.actions.Node(package='joy',
-                                       node_executable='joy_node',
+                                       executable='joy_node',
                                        output='both',
                                        parameters=[params])
 


### PR DESCRIPTION
# FIX
- closing #306 

This PR is fixing the usage of the *ComposableNode* and *Node* arguments to work under ros2 jazzy and rolling, by removing the outdated *node_* prefix for the class arguments
